### PR TITLE
[MVP] Intercept Price Estimation calculation inside state/swap/hooks useDerivedSwapInfo()

### DIFF
--- a/src/custom/state/swap/hooks.ts
+++ b/src/custom/state/swap/hooks.ts
@@ -1,0 +1,279 @@
+import { getTip } from '@src/custom/utils/price'
+import { useV1Trade } from '@src/data/V1'
+import { useActiveWeb3React } from '@src/hooks'
+import { useCurrency } from '@src/hooks/Tokens'
+import { useTradeExactIn, useTradeExactOut } from '@src/hooks/Trades'
+import useENS from '@src/hooks/useENS'
+import useToggledVersion, { Version } from '@src/hooks/useToggledVersion'
+import { Field } from '@src/state/swap/actions'
+import { tryParseAmount, useSwapState } from '@src/state/swap/hooks'
+import { useUserSlippageTolerance } from '@src/state/user/hooks'
+import { useCurrencyBalances } from '@src/state/wallet/hooks'
+import { isAddress } from '@src/utils'
+import { computeSlippageAdjustedAmounts } from '@src/utils/prices'
+import { Currency, CurrencyAmount, JSBI, Token, TokenAmount, Trade } from '@uniswap/sdk'
+
+export * from '@src/state/swap/hooks'
+
+const BAD_RECIPIENT_ADDRESSES: string[] = [
+  '0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f', // v2 factory
+  '0xf164fC0Ec4E93095b804a4795bBe1e041497b92a', // v2 router 01
+  '0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D' // v2 router 02
+]
+
+/**
+ * Returns true if any of the pairs or tokens in a trade have the given checksummed address
+ * @param trade to check for the given address
+ * @param checksummedAddress address to check in the pairs and tokens
+ */
+function involvesAddress(trade: Trade, checksummedAddress: string): boolean {
+  return (
+    trade.route.path.some(token => token.address === checksummedAddress) ||
+    trade.route.pairs.some(pair => pair.liquidityToken.address === checksummedAddress)
+  )
+}
+
+function tryValueToCurrency(value?: string, currency?: Currency): CurrencyAmount | undefined {
+  if (!value || !currency) {
+    return undefined
+  }
+  try {
+    if (value !== '0') {
+      return currency instanceof Token ? new TokenAmount(currency, value) : CurrencyAmount.ether(value)
+    }
+  } catch (error) {
+    // should fail if the user specifies too many decimal places of precision (or maybe exceed max uint?)
+    console.debug(`Failed to parse input amount: "${value}"`, error)
+  }
+  // necessary for all paths to return a value
+  return undefined
+}
+
+const useTradeWithTip = ({
+  currencyByInput,
+  inputCurrency,
+  outputCurrency,
+  isExactIn,
+  parsedAmount
+}: {
+  currencyByInput?: Currency
+  inputCurrency?: Currency | null
+  outputCurrency?: Currency | null
+  parsedAmount?: CurrencyAmount
+  isExactIn: boolean
+}) => {
+  const tip = getTip()
+  const parsedFeeAmount = tryParseAmount(tip, inputCurrency || undefined)
+
+  // Shows fee amount in OUTPUT token
+  const feeForTradeExactIn = useTradeExactIn(isExactIn ? parsedFeeAmount : undefined, outputCurrency ?? undefined)
+    ?.inputAmount
+  // Shows fee amount in INPUT token
+  const feeForTradeExactOut = useTradeExactOut(outputCurrency ?? undefined, !isExactIn ? parsedFeeAmount : undefined)
+    ?.inputAmount
+
+  const bestTradeExactIn = useTradeExactIn(
+    isExactIn
+      ? feeForTradeExactIn && parsedAmount
+        ? tryValueToCurrency(
+            // PARSED_USER_AMOUNT - FEE_AMOUNT
+            JSBI.subtract(parsedAmount.raw, feeForTradeExactIn.raw).toString(),
+            currencyByInput
+          )
+        : parsedAmount
+      : undefined,
+    outputCurrency ?? undefined
+  )
+
+  const bestTradeExactOut = useTradeExactOut(
+    inputCurrency ?? undefined,
+    !isExactIn
+      ? feeForTradeExactOut && parsedAmount
+        ? tryValueToCurrency(
+            // INPUTAMOUNT
+            JSBI.add(parsedAmount.raw, feeForTradeExactOut.raw).toString(),
+            currencyByInput
+          )
+        : parsedAmount
+      : undefined
+  )
+
+  return {
+    bestTradeExactIn,
+    bestTradeExactOut,
+    feeForTradeExactIn,
+    feeForTradeExactOut
+  }
+}
+
+// from the current swap inputs, compute the best trade and return it.
+export function useDerivedSwapInfo(): {
+  currencies: { [field in Field]?: Currency }
+  currencyBalances: { [field in Field]?: CurrencyAmount }
+  parsedAmount: CurrencyAmount | undefined
+  v2Trade: Trade | undefined
+  inputError?: string
+  v1Trade: Trade | undefined
+} {
+  const { account } = useActiveWeb3React()
+
+  const toggledVersion = useToggledVersion()
+
+  const {
+    independentField,
+    typedValue,
+    [Field.INPUT]: { currencyId: inputCurrencyId },
+    [Field.OUTPUT]: { currencyId: outputCurrencyId },
+    recipient
+  } = useSwapState()
+
+  const inputCurrency = useCurrency(inputCurrencyId)
+  const outputCurrency = useCurrency(outputCurrencyId)
+  const recipientLookup = useENS(recipient ?? undefined)
+  const to: string | null = (recipient === null ? account : recipientLookup.address) ?? null
+
+  const relevantTokenBalances = useCurrencyBalances(account ?? undefined, [
+    inputCurrency ?? undefined,
+    outputCurrency ?? undefined
+  ])
+
+  const isExactIn: boolean = independentField === Field.INPUT
+
+  const currencyByInput = (isExactIn ? inputCurrency : outputCurrency) ?? undefined
+
+  const parsedAmount = tryParseAmount(typedValue, currencyByInput)
+
+  const { bestTradeExactIn, bestTradeExactOut, feeForTradeExactIn, feeForTradeExactOut } = useTradeWithTip({
+    isExactIn,
+    currencyByInput,
+    inputCurrency,
+    outputCurrency,
+    parsedAmount
+  })
+
+  const bestTradeExactInBeforeFee = useTradeExactIn(isExactIn ? parsedAmount : undefined, outputCurrency ?? undefined)
+  const bestTradeExactOutBeforeFee = useTradeExactOut(inputCurrency ?? undefined, !isExactIn ? parsedAmount : undefined)
+
+  console.log(
+    '[LOGGING BEST TRADE] RAW PRICES',
+    `
+      [IN]
+      BEFORE FEE: ${bestTradeExactInBeforeFee?.inputAmount.toSignificant(
+        bestTradeExactInBeforeFee.inputAmount.currency.decimals
+      )}
+      FEE: ${feeForTradeExactIn?.toSignificant(feeForTradeExactIn.currency.decimals)}
+      PARSED AMT: ${parsedAmount?.toSignificant(feeForTradeExactIn?.currency.decimals)}
+      TRY PARSE AMT: ${parsedAmount &&
+        feeForTradeExactIn &&
+        tryValueToCurrency(
+          // INPUTAMOUNT
+          JSBI.subtract(parsedAmount.raw, feeForTradeExactIn.raw).toString(),
+          currencyByInput
+        )?.toSignificant(feeForTradeExactIn.currency.decimals)}
+      `,
+    tryParseAmount(
+      // INPUTAMOUNT
+      parsedAmount && feeForTradeExactIn && JSBI.subtract(parsedAmount.raw, feeForTradeExactIn.raw).toString(),
+      currencyByInput
+    )
+  )
+  console.log(
+    '[LOGGING BEST TRADE] RAW PRICES',
+    `
+      [OUT]
+      BEFORE FEE: ${bestTradeExactOutBeforeFee?.inputAmount.toSignificant(
+        bestTradeExactOutBeforeFee.inputAmount.currency.decimals
+      )}
+      FEE: ${feeForTradeExactOut?.toSignificant(feeForTradeExactOut.currency.decimals)}
+      PARSED AMT: ${parsedAmount?.toSignificant(currencyByInput?.decimals)}
+      TRY PARSE AMT: ${parsedAmount &&
+        feeForTradeExactOut &&
+        tryValueToCurrency(
+          // INPUTAMOUNT
+          JSBI.subtract(parsedAmount.raw, feeForTradeExactOut.raw).toString(),
+          currencyByInput
+        )?.toSignificant(feeForTradeExactOut.currency.decimals)}
+      `
+  )
+  // console.log('[LOGGING BEST TRADE] ===============================================')
+  // console.log('[LOGGING BEST TRADE IN] BEFORE FEE', bestTradeExactIn?.executionPrice.toFixed())
+  console.log('[LOGGING BEST TRADE IN] FEE', feeForTradeExactIn?.toSignificant(currencyByInput?.decimals))
+  // console.log('[LOGGING BEST TRADE IN] AFTER FEE', bestTradeExactIn)
+  // console.log('[LOGGING BEST TRADE] ===============================================')
+  // console.log('[LOGGING BEST TRADE OUT] BEFORE FEE', bestTradeExactOut?.executionPrice.toFixed())
+  console.log('[LOGGING BEST TRADE OUT] FEE', feeForTradeExactOut?.toSignificant(currencyByInput?.decimals))
+  // console.log('[LOGGING BEST TRADE OUT] AFTER FEE', bestTradeExactOut)
+
+  const v2Trade = isExactIn ? bestTradeExactIn : bestTradeExactOut
+
+  const currencyBalances = {
+    [Field.INPUT]: relevantTokenBalances[0],
+    [Field.OUTPUT]: relevantTokenBalances[1]
+  }
+
+  const currencies: { [field in Field]?: Currency } = {
+    [Field.INPUT]: inputCurrency ?? undefined,
+    [Field.OUTPUT]: outputCurrency ?? undefined
+  }
+
+  // get link to trade on v1, if a better rate exists
+  const v1Trade = useV1Trade(isExactIn, currencies[Field.INPUT], currencies[Field.OUTPUT], parsedAmount)
+
+  let inputError: string | undefined
+  if (!account) {
+    inputError = 'Connect Wallet'
+  }
+
+  if (!parsedAmount) {
+    inputError = inputError ?? 'Enter an amount'
+  }
+
+  if (!currencies[Field.INPUT] || !currencies[Field.OUTPUT]) {
+    inputError = inputError ?? 'Select a token'
+  }
+
+  const formattedTo = isAddress(to)
+  if (!to || !formattedTo) {
+    inputError = inputError ?? 'Enter a recipient'
+  } else {
+    if (
+      BAD_RECIPIENT_ADDRESSES.indexOf(formattedTo) !== -1 ||
+      (bestTradeExactIn && involvesAddress(bestTradeExactIn, formattedTo)) ||
+      (bestTradeExactOut && involvesAddress(bestTradeExactOut, formattedTo))
+    ) {
+      inputError = inputError ?? 'Invalid recipient'
+    }
+  }
+
+  const [allowedSlippage] = useUserSlippageTolerance()
+
+  const slippageAdjustedAmounts = v2Trade && allowedSlippage && computeSlippageAdjustedAmounts(v2Trade, allowedSlippage)
+
+  const slippageAdjustedAmountsV1 =
+    v1Trade && allowedSlippage && computeSlippageAdjustedAmounts(v1Trade, allowedSlippage)
+
+  // compare input balance to max input based on version
+  const [balanceIn, amountIn] = [
+    currencyBalances[Field.INPUT],
+    toggledVersion === Version.v1
+      ? slippageAdjustedAmountsV1
+        ? slippageAdjustedAmountsV1[Field.INPUT]
+        : null
+      : slippageAdjustedAmounts
+      ? slippageAdjustedAmounts[Field.INPUT]
+      : null
+  ]
+
+  if (balanceIn && amountIn && balanceIn.lessThan(amountIn)) {
+    inputError = 'Insufficient ' + amountIn.currency.symbol + ' balance'
+  }
+
+  return {
+    currencies,
+    currencyBalances,
+    parsedAmount,
+    v2Trade: v2Trade ?? undefined,
+    inputError,
+    v1Trade
+  }
+}

--- a/src/custom/state/swap/hooks.ts
+++ b/src/custom/state/swap/hooks.ts
@@ -80,7 +80,7 @@ const useCalculateTip = ({ inputCurrency, outputCurrency, isExactIn, parsedAmoun
   const feeForTradeExactIn = useTradeExactIn(isExactIn ? parsedFeeAmount : undefined, outputCurrency ?? undefined)
     ?.inputAmount
   // Shows fee amount in INPUT token
-  const feeForTradeExactOut = useTradeExactOut(outputCurrency ?? undefined, !isExactIn ? parsedFeeAmount : undefined)
+  const feeForTradeExactOut = useTradeExactOut(inputCurrency ?? undefined, !isExactIn ? parsedFeeAmount : undefined)
     ?.inputAmount
 
   const tipAmount = calculateTipInOrOut({

--- a/src/custom/state/swap/hooks.ts
+++ b/src/custom/state/swap/hooks.ts
@@ -100,9 +100,7 @@ const useTradeWithTip = ({
 
   return {
     bestTradeExactIn,
-    bestTradeExactOut,
-    feeForTradeExactIn,
-    feeForTradeExactOut
+    bestTradeExactOut
   }
 }
 
@@ -143,66 +141,13 @@ export function useDerivedSwapInfo(): {
 
   const parsedAmount = tryParseAmount(typedValue, currencyByInput)
 
-  const { bestTradeExactIn, bestTradeExactOut, feeForTradeExactIn, feeForTradeExactOut } = useTradeWithTip({
+  const { bestTradeExactIn, bestTradeExactOut } = useTradeWithTip({
     isExactIn,
     currencyByInput,
     inputCurrency,
     outputCurrency,
     parsedAmount
   })
-
-  const bestTradeExactInBeforeFee = useTradeExactIn(isExactIn ? parsedAmount : undefined, outputCurrency ?? undefined)
-  const bestTradeExactOutBeforeFee = useTradeExactOut(inputCurrency ?? undefined, !isExactIn ? parsedAmount : undefined)
-
-  console.log(
-    '[LOGGING BEST TRADE] RAW PRICES',
-    `
-      [IN]
-      BEFORE FEE: ${bestTradeExactInBeforeFee?.inputAmount.toSignificant(
-        bestTradeExactInBeforeFee.inputAmount.currency.decimals
-      )}
-      FEE: ${feeForTradeExactIn?.toSignificant(feeForTradeExactIn.currency.decimals)}
-      PARSED AMT: ${parsedAmount?.toSignificant(feeForTradeExactIn?.currency.decimals)}
-      TRY PARSE AMT: ${parsedAmount &&
-        feeForTradeExactIn &&
-        tryValueToCurrency(
-          // INPUTAMOUNT
-          JSBI.subtract(parsedAmount.raw, feeForTradeExactIn.raw).toString(),
-          currencyByInput
-        )?.toSignificant(feeForTradeExactIn.currency.decimals)}
-      `,
-    tryParseAmount(
-      // INPUTAMOUNT
-      parsedAmount && feeForTradeExactIn && JSBI.subtract(parsedAmount.raw, feeForTradeExactIn.raw).toString(),
-      currencyByInput
-    )
-  )
-  console.log(
-    '[LOGGING BEST TRADE] RAW PRICES',
-    `
-      [OUT]
-      BEFORE FEE: ${bestTradeExactOutBeforeFee?.inputAmount.toSignificant(
-        bestTradeExactOutBeforeFee.inputAmount.currency.decimals
-      )}
-      FEE: ${feeForTradeExactOut?.toSignificant(feeForTradeExactOut.currency.decimals)}
-      PARSED AMT: ${parsedAmount?.toSignificant(currencyByInput?.decimals)}
-      TRY PARSE AMT: ${parsedAmount &&
-        feeForTradeExactOut &&
-        tryValueToCurrency(
-          // INPUTAMOUNT
-          JSBI.subtract(parsedAmount.raw, feeForTradeExactOut.raw).toString(),
-          currencyByInput
-        )?.toSignificant(feeForTradeExactOut.currency.decimals)}
-      `
-  )
-  // console.log('[LOGGING BEST TRADE] ===============================================')
-  // console.log('[LOGGING BEST TRADE IN] BEFORE FEE', bestTradeExactIn?.executionPrice.toFixed())
-  console.log('[LOGGING BEST TRADE IN] FEE', feeForTradeExactIn?.toSignificant(currencyByInput?.decimals))
-  // console.log('[LOGGING BEST TRADE IN] AFTER FEE', bestTradeExactIn)
-  // console.log('[LOGGING BEST TRADE] ===============================================')
-  // console.log('[LOGGING BEST TRADE OUT] BEFORE FEE', bestTradeExactOut?.executionPrice.toFixed())
-  console.log('[LOGGING BEST TRADE OUT] FEE', feeForTradeExactOut?.toSignificant(currencyByInput?.decimals))
-  // console.log('[LOGGING BEST TRADE OUT] AFTER FEE', bestTradeExactOut)
 
   const v2Trade = isExactIn ? bestTradeExactIn : bestTradeExactOut
 

--- a/src/custom/state/swap/hooks.ts
+++ b/src/custom/state/swap/hooks.ts
@@ -13,12 +13,6 @@ import { Currency, CurrencyAmount, JSBI, Token, TokenAmount, Trade } from '@unis
 
 export * from '@src/state/swap/hooks'
 
-const BAD_RECIPIENT_ADDRESSES: string[] = [
-  '0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f', // v2 factory
-  '0xf164fC0Ec4E93095b804a4795bBe1e041497b92a', // v2 router 01
-  '0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D' // v2 router 02
-]
-
 /**
  * Returns true if any of the pairs or tokens in a trade have the given checksummed address
  * @param trade to check for the given address
@@ -189,7 +183,6 @@ export function useDerivedSwapInfo(): DerivedSwapInfo {
     inputError = inputError ?? 'Enter a recipient'
   } else {
     if (
-      BAD_RECIPIENT_ADDRESSES.indexOf(formattedTo) !== -1 ||
       (bestTradeExactIn && involvesAddress(bestTradeExactIn, formattedTo)) ||
       (bestTradeExactOut && involvesAddress(bestTradeExactOut, formattedTo))
     ) {
@@ -215,7 +208,10 @@ export function useDerivedSwapInfo(): DerivedSwapInfo {
     currencies,
     currencyBalances,
     parsedAmount,
+    // leave type name the same, but see this as our main "trade" or "swap"
     v2Trade: trade ?? undefined,
+    // as we dont have "v1" OR "v2" we just return undefined here
+    // as to not require also extending pages/Swap
     v1Trade: undefined,
     inputError
   }

--- a/src/custom/utils/price.ts
+++ b/src/custom/utils/price.ts
@@ -1,6 +1,6 @@
 export * from '@src/utils/prices'
 
-const DEFAULT_TIP = '5'
+const DEFAULT_TIP = '0'
 
 // TODO: add mock API using Alex's created open API definition of tip endpoint
 export const getTip = (): string => DEFAULT_TIP

--- a/src/custom/utils/price.ts
+++ b/src/custom/utils/price.ts
@@ -1,6 +1,6 @@
 export * from '@src/utils/prices'
 
-const DEFAULT_TIP = '0'
+const DEFAULT_TIP = '5'
 
 // TODO: add mock API using Alex's created open API definition of tip endpoint
 export const getTip = (): string => DEFAULT_TIP

--- a/src/custom/utils/price.ts
+++ b/src/custom/utils/price.ts
@@ -1,0 +1,11 @@
+export * from '@src/utils/prices'
+
+const DEFAULT_TIP = '5'
+
+// TODO: add mock API using Alex's created open API definition of tip endpoint
+export const getTip = (): string | undefined => {
+  // TODO: replace with fetch call to OBA-API TIP endpoint
+  const fakeTip: string | undefined = !!(Math.random() % 3) ? DEFAULT_TIP : undefined
+
+  return fakeTip
+}

--- a/src/custom/utils/price.ts
+++ b/src/custom/utils/price.ts
@@ -3,9 +3,4 @@ export * from '@src/utils/prices'
 const DEFAULT_TIP = '5'
 
 // TODO: add mock API using Alex's created open API definition of tip endpoint
-export const getTip = (): string | undefined => {
-  // TODO: replace with fetch call to OBA-API TIP endpoint
-  const fakeTip: string | undefined = !!(Math.random() % 3) ? DEFAULT_TIP : undefined
-
-  return fakeTip
-}
+export const getTip = (): string => DEFAULT_TIP

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -31,12 +31,7 @@ import useToggledVersion, { DEFAULT_VERSION, Version } from '../../hooks/useTogg
 import useWrapCallback, { WrapType } from '../../hooks/useWrapCallback'
 import { useToggleSettingsMenu, useWalletModalToggle } from '../../state/application/hooks'
 import { Field } from '../../state/swap/actions'
-import {
-  useDefaultsFromURLSearch,
-  useDerivedSwapInfo,
-  useSwapActionHandlers,
-  useSwapState
-} from '../../state/swap/hooks'
+import { useDefaultsFromURLSearch, useDerivedSwapInfo, useSwapActionHandlers, useSwapState } from 'state/swap/hooks'
 import { useExpertModeManager, useUserSlippageTolerance } from '../../state/user/hooks'
 import { LinkStyledButton, TYPE } from 'theme'
 import { maxAmountSpend } from '../../utils/maxAmountSpend'


### PR DESCRIPTION
Part of #32 

- [x] Initial logic that overrides useDerivedSwapInfo and calculates exactIn/Out values w/tip injected (this PR)
- [ ] Mock async `getTip` API endpoint to await on and get fake tip value #35 
- [ ] Implement 'real' `getTip` endpoint (TBD PR)

#### Status: draft

## Summary
- Uni uses `/state/swap/hooks > useDerivedSwapInfo` hook to calculate the `Trade` data based on:
1. user's input amount
2. which input field (sell/buy) the user input the amount into
3. the returned trade info from their `useTradeExactIn` and `useTradeExactOut` hooks, which ultimately calls:
```ts
Trade.bestTradeExactIn(allowedPairs, currencyAmountIn, currencyOut, { maxHops: 3, maxNumResults: 1 })[0] ?? null
```

- I am overriding this hook and:
1. inserting a custom `useTradeWithTip` hook to calculate the trade with tip in mind
e.g user is adjusting the sell token input (let's say weth) for GNO. This hook determines which input is being manipulated (in our case it's the sell token), and then calls the original `useTradeExactIn` hook using the input amount as `userInputAmount - mockFeeAmount` 
2. The `useTradeWithTip` hook also checks if the opposite is happening (user adjusting the buyToken amounts) and adjusts the necessary sell amount accordingly. This can be tested in this PR by doing:
1. Sell WETH (or ETH)
2. Buy GNO
3. Set parameters to: Sell `6 WETH`
  3a. Uni calculates the trade info and will deduct 5 WETH from sell amount
  3b. Estimated received GNO will be shown as (6 WETH - 5 WETH_TIP = 1 WETH) = ~8GNO
4. Set parameters to `- WETH` (clear the WETH input) & set `9 GNO`
  4a. Uni calculates the trade info and will deduct the same from the required input amount to match the numbers from `step 3` showing ~1WETH for setting receive ~9GNO (approx. as prices change)


