### PR TITLE
Price estimation tip api

### DIFF
--- a/src/custom/state/index.ts
+++ b/src/custom/state/index.ts
@@ -13,6 +13,8 @@ import burn from '@src/state/burn/reducer'
 import multicall from '@src/state/multicall/reducer'
 // CUSTOM REDUCERS
 import operator from './operator/reducer'
+// CUSTOM MIDDLEWARE
+import { applyTipMiddleware } from './operator/middleware'
 
 const UNISWAP_REDUCERS = {
   application,
@@ -25,14 +27,14 @@ const UNISWAP_REDUCERS = {
   lists
 }
 
-const PERSISTED_KEYS: string[] = ['user', 'transactions', 'lists']
+const PERSISTED_KEYS: string[] = ['user', 'transactions', 'lists', 'operator']
 
 const store = configureStore({
   reducer: {
     ...UNISWAP_REDUCERS,
     operator
   },
-  middleware: [...getDefaultMiddleware({ thunk: false }), save({ states: PERSISTED_KEYS })],
+  middleware: [...getDefaultMiddleware({ thunk: false }), save({ states: PERSISTED_KEYS }), applyTipMiddleware],
   preloadedState: load({ states: PERSISTED_KEYS })
 })
 

--- a/src/custom/state/operator/actions.ts
+++ b/src/custom/state/operator/actions.ts
@@ -1,6 +1,6 @@
 import { createAction } from '@reduxjs/toolkit'
 
-export type Tip = number
+export type Tip = string
 
 export const updateTip = createAction<{ token: string; tip: Tip }>('operator/updateTip')
 export const clearTip = createAction<{ token: string }>('operator/clearTip')

--- a/src/custom/state/operator/hooks.ts
+++ b/src/custom/state/operator/hooks.ts
@@ -14,10 +14,10 @@ interface ClearTipParams {
 type AddTipCallback = (addTokenParams: AddTipParams) => void
 type ClearTipCallback = (clearTokenParams: ClearTipParams) => void
 
-export const useTip = (tokenAddress: string): Tip | undefined => {
+export const useTip = (tokenAddress?: string): Tip | undefined => {
   const { tipsMap } = useSelector<AppState, OperatorState>(state => state.operator)
 
-  return tipsMap[tokenAddress]?.tip
+  return tokenAddress ? tipsMap[tokenAddress]?.tip : undefined
 }
 
 export const useAddTip = (): AddTipCallback => {

--- a/src/custom/state/operator/middleware.ts
+++ b/src/custom/state/operator/middleware.ts
@@ -1,6 +1,6 @@
 import { Middleware } from '@reduxjs/toolkit'
 import { getTip } from '@src/custom/utils/price'
-import { Field, selectCurrency } from '@src/state/swap/actions'
+import { selectCurrency } from '@src/state/swap/actions'
 import { updateTip } from './actions'
 import { OperatorState } from './reducer'
 
@@ -9,8 +9,11 @@ export const applyTipMiddleware: Middleware = ({ dispatch, getState }) => next =
   const isTriggerAction = action.type === selectCurrency.type
 
   if (isTriggerAction) {
-    const { payload } = action as ReturnType<typeof selectCurrency>
-    const isSellToken = payload?.field === Field.INPUT
+    const { payload } = action
+
+    // check actions as several should trigger this update
+    // e.g direct selection? yes, also has payload to check token type
+    // but switchCurrencies? has no payload, but must be used to check tip
 
     const {
       operator: { tipsMap }
@@ -32,10 +35,9 @@ export const applyTipMiddleware: Middleware = ({ dispatch, getState }) => next =
     ========================================================
     🚀  [TIP MIDDLEWARE] SELECT_CURRENCY ACTION DETECTED
 
-        SELL/BUY: ${isSellToken ? 'SELL' : 'BUY'}
 
         PAYLOAD:  ${JSON.stringify(payload, null, 2)}
-        TIP:      ${tokenTip}
+        TIP:      ${getState().operator.tipsMap[payload.currencyId]?.tip}
     ========================================================
       `)
   }

--- a/src/custom/state/operator/middleware.ts
+++ b/src/custom/state/operator/middleware.ts
@@ -1,5 +1,5 @@
 import { Middleware } from '@reduxjs/toolkit'
-import { getTip } from '@src/custom/utils/price'
+import { getTip } from '@src/custom/utils/fees'
 import { selectCurrency } from '@src/state/swap/actions'
 import { updateTip } from './actions'
 import { OperatorState } from './reducer'

--- a/src/custom/state/operator/middleware.ts
+++ b/src/custom/state/operator/middleware.ts
@@ -1,0 +1,44 @@
+import { Middleware } from '@reduxjs/toolkit'
+import { getTip } from '@src/custom/utils/price'
+import { Field, selectCurrency } from '@src/state/swap/actions'
+import { updateTip } from './actions'
+import { OperatorState } from './reducer'
+
+export const applyTipMiddleware: Middleware = ({ dispatch, getState }) => next => async action => {
+  // check that incoming action is a selected token
+  const isTriggerAction = action.type === selectCurrency.type
+
+  if (isTriggerAction) {
+    const { payload } = action as ReturnType<typeof selectCurrency>
+    const isSellToken = payload?.field === Field.INPUT
+
+    const {
+      operator: { tipsMap }
+    }: { operator: OperatorState } = getState()
+
+    const tokenTip = tipsMap[payload.currencyId]?.tip
+
+    if (!tokenTip) {
+      const tip = await getTip(payload.currencyId)
+      dispatch(
+        updateTip({
+          token: payload.currencyId,
+          tip
+        })
+      )
+    }
+
+    console.debug(`
+    ========================================================
+    🚀  [TIP MIDDLEWARE] SELECT_CURRENCY ACTION DETECTED
+
+        SELL/BUY: ${isSellToken ? 'SELL' : 'BUY'}
+
+        PAYLOAD:  ${JSON.stringify(payload, null, 2)}
+        TIP:      ${tokenTip}
+    ========================================================
+      `)
+  }
+
+  next(action)
+}

--- a/src/custom/state/swap/hooks.ts
+++ b/src/custom/state/swap/hooks.ts
@@ -1,4 +1,3 @@
-import { getTip } from '@src/custom/utils/price'
 import { useActiveWeb3React } from '@src/hooks'
 import { useCurrency } from '@src/hooks/Tokens'
 import { useTradeExactIn, useTradeExactOut } from '@src/hooks/Trades'
@@ -10,6 +9,7 @@ import { useCurrencyBalances } from '@src/state/wallet/hooks'
 import { isAddress } from '@src/utils'
 import { computeSlippageAdjustedAmounts } from '@src/utils/prices'
 import { Currency, CurrencyAmount, JSBI, Token, TokenAmount, Trade } from '@uniswap/sdk'
+import { useTip } from '../operator/hooks'
 
 export * from '@src/state/swap/hooks'
 
@@ -70,15 +70,17 @@ interface TradeCalculation {
   outputCurrency?: Currency | null
   parsedAmount?: CurrencyAmount
   isExactIn: boolean
+  tokenAddress?: string
 }
 
 const useCalculateTip = ({ inputCurrency, outputCurrency, isExactIn, parsedAmount }: TradeCalculation) => {
-  const tip = getTip()
+  const tip = useTip()
   const parsedFeeAmount = tryParseAmount(tip, inputCurrency || undefined)
 
   // Shows fee amount in OUTPUT token
   const feeForTradeExactIn = useTradeExactIn(isExactIn ? parsedFeeAmount : undefined, outputCurrency ?? undefined)
     ?.inputAmount
+
   // Shows fee amount in INPUT token
   const feeForTradeExactOut = useTradeExactOut(inputCurrency ?? undefined, !isExactIn ? parsedFeeAmount : undefined)
     ?.inputAmount
@@ -138,7 +140,8 @@ export function useDerivedSwapInfo(): DerivedSwapInfo {
     isExactIn,
     inputCurrency,
     outputCurrency,
-    parsedAmount
+    parsedAmount,
+    tokenAddress: inputCurrencyId
   })
 
   const bestTradeExactIn = useTradeExactIn(calculatedTip, outputCurrency ?? undefined)

--- a/src/custom/state/swap/hooks.ts
+++ b/src/custom/state/swap/hooks.ts
@@ -73,8 +73,14 @@ interface TradeCalculation {
   tokenAddress?: string
 }
 
-const useCalculateTip = ({ inputCurrency, outputCurrency, isExactIn, parsedAmount }: TradeCalculation) => {
-  const tip = useTip()
+const useCalculateTip = ({
+  inputCurrency,
+  outputCurrency,
+  isExactIn,
+  parsedAmount,
+  tokenAddress
+}: TradeCalculation) => {
+  const tip = useTip(tokenAddress)
   const parsedFeeAmount = tryParseAmount(tip, inputCurrency || undefined)
 
   // Shows fee amount in OUTPUT token

--- a/src/custom/utils/fees.ts
+++ b/src/custom/utils/fees.ts
@@ -1,4 +1,9 @@
 // TODO: add mock API using Alex's created open API definition of tip endpoint
+/**
+ * @name getTip
+ * @param currencyId token address as string
+ * @description queries oba services endpoint for sell token tip amount set by operator
+ */
 export const getTip = async (currencyId: string): Promise<string> =>
   new Promise(accept => {
     return setTimeout(() => {

--- a/src/custom/utils/fees.ts
+++ b/src/custom/utils/fees.ts
@@ -1,5 +1,3 @@
-export * from '@src/utils/prices'
-
 // TODO: add mock API using Alex's created open API definition of tip endpoint
 export const getTip = async (currencyId: string): Promise<string> =>
   new Promise(accept => {

--- a/src/custom/utils/price.ts
+++ b/src/custom/utils/price.ts
@@ -1,6 +1,11 @@
 export * from '@src/utils/prices'
 
-const DEFAULT_TIP = '5'
-
 // TODO: add mock API using Alex's created open API definition of tip endpoint
-export const getTip = (): string => DEFAULT_TIP
+export const getTip = async (currencyId: string): Promise<string> =>
+  new Promise(accept => {
+    return setTimeout(() => {
+      console.debug(`[MOCK] utils/price::getTip ==> API request for token ${currencyId}`)
+      const computedTip = Math.floor(Math.random() * 10).toString()
+      accept(computedTip)
+    }, Math.floor(Math.random() * 1000))
+  })


### PR DESCRIPTION
### Part of #32 

### Merges into #33 

## Summary
- Creates mock api endpoint thing, `getTip` for grabbing tip amount as string passing sellToken address as arg
- Fixes some logic in calculating tip on Trade object in useDerivedSwapInfo
- fixes some action/reducer state redux stuff regarding operator and it's relevant hooks

## Alternatives
- instead of middleware, tip calculation could be done inside `swap/hooks > useSwapActionHandlers` here:
```ts
async function checkAndSetTip(currencyId: string): Promise<void> {
    const tokenTip = useTip(currencyId)
    const addTip = useAddTip()

    if (!tokenTip) {
      const tip = await getTip(currencyId)
      addTip({
          token: currencyId,
          tip,
      })
    }
}

function useSwapActionHandlers(): {
  ...types,
} {
const onCurrencySelection = useCallback(
    async (field: Field, currency: Currency) => {
      const currencyId = currency instanceof Token ? currency.address : currency === ETHER ? 'ETH' : ''
      
      dispatch(
        selectCurrency({
          field,
          currencyId,
        })
      )

      return checkAndSetTip(currencyId)
    },
    [dispatch]
  )

  const onSwitchTokens = useCallback(() => {
    dispatch(switchCurrencies())
  }, [dispatch])
...
}
```