### PR TITLE
Do not check immutable changes, is too slow

### DIFF
--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -24,7 +24,13 @@ const store = configureStore({
     multicall,
     lists
   },
-  middleware: [...getDefaultMiddleware({ thunk: false }), save({ states: PERSISTED_KEYS })],
+  middleware: [
+    ...getDefaultMiddleware({
+      thunk: false,
+      immutableCheck: false
+    }),
+    save({ states: PERSISTED_KEYS })
+  ],
   preloadedState: load({ states: PERSISTED_KEYS })
 })
 


### PR DESCRIPTION
Quick fix for disabling the checks that SLOW DOWN SO MUCH the app for development

We can ignore all but our stores too, but went for disabling all:
https://redux-toolkit.js.org/api/getDefaultMiddleware#customizing-the-included-middleware 
https://redux-toolkit.js.org/api/immutabilityMiddleware#createimmutablestateinvariantmiddleware 

We just don't mutate the thing :) 