### PR TITLE
Disable token warning

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,7 @@
 REACT_APP_CHAIN_ID="1"
 REACT_APP_NETWORK_URL="https://mainnet.infura.io/v3/4bf032f2d38a4ed6bb975b80d6340847"
+
+# If true. Do not warn the user if he is selecting a token via URL. Just convenient for development
+# for example, for using an url for pre-selecting the trade details
+#   i.e. http://localhost:3000/#/swap?inputCurrency=ETH&outputCurrency=0x5592EC0cfb4dbc12D3aB100b257153436a1f0FEa&exactAmount=0.15
+REACT_APP_DISABLE_TOKEN_WARNING=true

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -53,7 +53,9 @@ export default function Swap() {
     useCurrency(loadedUrlParams?.inputCurrencyId),
     useCurrency(loadedUrlParams?.outputCurrencyId)
   ]
-  const [dismissTokenWarning, setDismissTokenWarning] = useState<boolean>(false)
+  const [dismissTokenWarning, setDismissTokenWarning] = useState<boolean>(
+    process.env.REACT_APP_DISABLE_TOKEN_WARNING === 'true'
+  )
   const urlLoadedTokens: Token[] = useMemo(
     () => [loadedInputCurrency, loadedOutputCurrency]?.filter((c): c is Token => c instanceof Token) ?? [],
     [loadedInputCurrency, loadedOutputCurrency]


### PR DESCRIPTION
This PR is just because for doing some local tests, I had to fill the form many times

It helped a lot, loading and pre-filling the web by using an URL, for example:
http://localhost:3000/#/swap?inputCurrency=ETH&outputCurrency=0x5592EC0cfb4dbc12D3aB100b257153436a1f0FEa&exactAmount=0.15

However, this will show every single time this horrible modal
<img width="1779" alt="Screenshot at Dec 07 20-37-53" src="https://user-images.githubusercontent.com/2352112/101399285-8e329f00-38cf-11eb-91bf-062e44c5c09d.png">

This PR introduces a new env var to prevent this modal from showing.
`REACT_APP_DISABLE_TOKEN_WARNING`

I added this for myself first, but then I thought about doing a PR, since it might be useful for the others :) 