### PR TITLE
Approve by network

### DIFF
--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -10,7 +10,7 @@ export const GP_SETTLEMENT_CONTRACT_ADDRESS: Partial<Record<ChainId, string>> = 
   // TODO: extend chainId for adding xDAI
 }
 
-export const GP_SETTLEMENT_CONTRACT_ADDRESS: Partial<Record<ChainId, string>> = {
+export const GP_ALLOWANCE_MANAGER_CONTRACT_ADDRESS: Partial<Record<ChainId, string>> = {
   [ChainId.MAINNET]: '0x6F400810b62df8E13fded51bE75fF5393eaa841F',
   [ChainId.RINKEBY]: '0xC576eA7bd102F7E476368a5E98FA455d1Ea34dE2'
   // TODO: extend chainId for adding xDAI

--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -4,20 +4,14 @@ import { ChainId } from '@uniswap/sdk'
 export * from '@src/constants/index'
 
 // TODO: When contracts are deployed, we can load this from the NPM package
-export const GP_SETTLEMENT_CONTRACT_ADDRESS: Record<ChainId, string | undefined> = {
+export const GP_SETTLEMENT_CONTRACT_ADDRESS: Partial<Record<ChainId, string>> = {
   [ChainId.MAINNET]: '0x6F400810b62df8E13fded51bE75fF5393eaa841F',
-  [ChainId.RINKEBY]: '0xC576eA7bd102F7E476368a5E98FA455d1Ea34dE2',
-  [ChainId.GÖRLI]: undefined,
-  [ChainId.KOVAN]: undefined,
-  [ChainId.ROPSTEN]: undefined
+  [ChainId.RINKEBY]: '0xC576eA7bd102F7E476368a5E98FA455d1Ea34dE2'
   // TODO: extend chainId for adding xDAI
 }
 
-export const GP_ALLOWANCE_MANAGER_CONTRACT_ADDRESS: Record<ChainId, string | undefined> = {
+export const GP_SETTLEMENT_CONTRACT_ADDRESS: Partial<Record<ChainId, string>> = {
   [ChainId.MAINNET]: '0x6F400810b62df8E13fded51bE75fF5393eaa841F',
-  [ChainId.RINKEBY]: '0xC576eA7bd102F7E476368a5E98FA455d1Ea34dE2',
-  [ChainId.GÖRLI]: undefined,
-  [ChainId.KOVAN]: undefined,
-  [ChainId.ROPSTEN]: undefined
+  [ChainId.RINKEBY]: '0xC576eA7bd102F7E476368a5E98FA455d1Ea34dE2'
   // TODO: extend chainId for adding xDAI
 }

--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -1,4 +1,23 @@
+import { ChainId } from '@uniswap/sdk'
+
 // reexport everything
 export * from '@src/constants/index'
-// override specifics
-export const ROUTER_ADDRESS = '0x1111111111111111111111111111111111111111'
+
+// TODO: When contracts are deployed, we can load this from the NPM package
+export const GP_SETTLEMENT_CONTRACT_ADDRESS: Record<ChainId, string | undefined> = {
+  [ChainId.MAINNET]: '0x6F400810b62df8E13fded51bE75fF5393eaa841F',
+  [ChainId.RINKEBY]: '0xC576eA7bd102F7E476368a5E98FA455d1Ea34dE2',
+  [ChainId.GÖRLI]: undefined,
+  [ChainId.KOVAN]: undefined,
+  [ChainId.ROPSTEN]: undefined
+  // TODO: extend chainId for adding xDAI
+}
+
+export const GP_ALLOWANCE_MANAGER_CONTRACT_ADDRESS: Record<ChainId, string | undefined> = {
+  [ChainId.MAINNET]: '0x6F400810b62df8E13fded51bE75fF5393eaa841F',
+  [ChainId.RINKEBY]: '0xC576eA7bd102F7E476368a5E98FA455d1Ea34dE2',
+  [ChainId.GÖRLI]: undefined,
+  [ChainId.KOVAN]: undefined,
+  [ChainId.ROPSTEN]: undefined
+  // TODO: extend chainId for adding xDAI
+}

--- a/src/custom/hooks/useApproveCallback.ts
+++ b/src/custom/hooks/useApproveCallback.ts
@@ -1,0 +1,25 @@
+import { useActiveWeb3React } from '@src/hooks'
+import { useApproveCallback } from '@src/hooks/useApproveCallback'
+import { Field } from '@src/state/swap/actions'
+import { computeSlippageAdjustedAmounts } from '@src/utils/prices'
+import { Trade } from '@uniswap/sdk'
+import { useMemo } from 'react'
+import { GP_ALLOWANCE_MANAGER_CONTRACT_ADDRESS } from '../constants'
+
+export { ApprovalState } from '@src/hooks/useApproveCallback'
+
+export function useApproveCallbackFromTrade(trade?: Trade, allowedSlippage = 0) {
+  const { chainId } = useActiveWeb3React()
+
+  const amountToApprove = useMemo(() => {
+    if (trade) {
+      const slippageForTrade = computeSlippageAdjustedAmounts(trade, allowedSlippage)
+      return slippageForTrade[Field.INPUT]
+    }
+    return undefined
+  }, [trade, allowedSlippage])
+
+  const allowanceManager = chainId ? GP_ALLOWANCE_MANAGER_CONTRACT_ADDRESS[chainId] : undefined
+
+  return useApproveCallback(amountToApprove, allowanceManager)
+}

--- a/src/custom/hooks/useApproveCallback.ts
+++ b/src/custom/hooks/useApproveCallback.ts
@@ -19,7 +19,7 @@ export function useApproveCallbackFromTrade(trade?: Trade, allowedSlippage = 0) 
     return undefined
   }, [trade, allowedSlippage])
 
-  const allowanceManager = chainId ? GP_ALLOWANCE_MANAGER_CONTRACT_ADDRESS[chainId] : undefined
+  const allowanceManager = chainId && GP_ALLOWANCE_MANAGER_CONTRACT_ADDRESS[chainId]
 
   return useApproveCallback(amountToApprove, allowanceManager)
 }

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -24,7 +24,7 @@ import { BETTER_TRADE_LINK_THRESHOLD, INITIAL_ALLOWED_SLIPPAGE } from '../../con
 import { getTradeVersion, isTradeBetter } from '../../data/V1'
 import { useActiveWeb3React } from '../../hooks'
 import { useCurrency } from '../../hooks/Tokens'
-import { ApprovalState, useApproveCallbackFromTrade } from '../../hooks/useApproveCallback'
+import { ApprovalState, useApproveCallbackFromTrade } from 'hooks/useApproveCallback'
 import useENSAddress from '../../hooks/useENSAddress'
 import { useSwapCallback } from 'hooks/useSwapCallback'
 import useToggledVersion, { DEFAULT_VERSION, Version } from '../../hooks/useToggledVersion'


### PR DESCRIPTION
The approve had the address hardcoded hardcoded

This PR:
* Define the addresses of the contracts by network (uses GPv1 for now, since contracts are not deployed yet)
* Overrides the hook involved in approving
* Delegates to the "general" approve hook handing in the right address