### PR TITLE
Post signed order to the operator

### DIFF
--- a/src/custom/state/operator/actions.ts
+++ b/src/custom/state/operator/actions.ts
@@ -1,11 +1,5 @@
 import { createAction } from '@reduxjs/toolkit'
 
-/**
- * Unique identifier for the order, calculated by keccak256(orderDigest, ownerAddress, validTo),
-   where orderDigest = keccak256(orderStruct). bytes32.
- */
-export type OrderID = string
-
 export type Tip = number
 
 export const updateTip = createAction<{ token: string; tip: Tip }>('operator/updateTip')

--- a/src/custom/state/orders/actions.ts
+++ b/src/custom/state/orders/actions.ts
@@ -1,6 +1,6 @@
 import { createAction } from '@reduxjs/toolkit'
-import { OrderID } from '@src/custom/utils/operator'
-import { OrderCreation } from '@src/custom/utils/signatures'
+import { OrderID } from 'utils/operator'
+import { OrderCreation } from 'utils/signatures'
 import { ChainId } from '@uniswap/sdk'
 
 export enum OrderStatus {

--- a/src/custom/state/orders/actions.ts
+++ b/src/custom/state/orders/actions.ts
@@ -1,19 +1,7 @@
 import { createAction } from '@reduxjs/toolkit'
-import { UnsignedOrder } from '@src/custom/utils/signatures'
+import { OrderID } from '@src/custom/utils/operator'
+import { OrderCreation } from '@src/custom/utils/signatures'
 import { ChainId } from '@uniswap/sdk'
-
-export enum OrderKind {
-  SELL = 'sell',
-  BUY = 'buy'
-}
-
-// posted to /api/v1/orders on Order creation
-// serializable, so no BigNumbers
-//  See https://protocol-rinkeby.dev.gnosisdev.com/api/
-export interface OrderCreation extends UnsignedOrder {
-  // TODO: I commented this because I expect the API and contract to follow the same structure for the order data. confirm and delete this comment
-  signature: string // 65 bytes encoded as hex without `0x` prefix. v + r + s from the spec
-}
 
 export enum OrderStatus {
   PENDING = 'pending',
@@ -35,12 +23,6 @@ export interface OrderFromApi extends OrderCreation {
   creationTime: string // Creation time of the order. Encoded as ISO 8601 UTC
   owner: string // address, without '0x' prefix
 }
-
-/**
- * Unique identifier for the order, calculated by keccak256(orderDigest, ownerAddress, validTo),
-   where orderDigest = keccak256(orderStruct). bytes32.
- */
-export type OrderID = string
 
 export interface AddPendingOrderParams {
   id: OrderID

--- a/src/custom/state/orders/hooks.ts
+++ b/src/custom/state/orders/hooks.ts
@@ -3,9 +3,10 @@ import { useCallback, useMemo } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { AppDispatch, AppState } from 'state'
-import { addPendingOrder, removeOrder, clearOrders, fulfillOrder, Order, OrderID } from './actions'
+import { addPendingOrder, removeOrder, clearOrders, fulfillOrder, Order } from './actions'
 import { OrdersState, PartialOrdersMap } from './reducer'
 import { isTruthy } from 'utils/misc'
+import { OrderID } from '@src/custom/utils/operator'
 
 interface AddPendingOrderParams extends GetRemoveOrderParams {
   order: Order

--- a/src/custom/state/orders/hooks.ts
+++ b/src/custom/state/orders/hooks.ts
@@ -6,7 +6,7 @@ import { AppDispatch, AppState } from 'state'
 import { addPendingOrder, removeOrder, clearOrders, fulfillOrder, Order } from './actions'
 import { OrdersState, PartialOrdersMap } from './reducer'
 import { isTruthy } from 'utils/misc'
-import { OrderID } from '@src/custom/utils/operator'
+import { OrderID } from 'utils/operator'
 
 interface AddPendingOrderParams extends GetRemoveOrderParams {
   order: Order

--- a/src/custom/state/orders/reducer.ts
+++ b/src/custom/state/orders/reducer.ts
@@ -1,6 +1,7 @@
 import { createReducer, PayloadAction } from '@reduxjs/toolkit'
+import { OrderID } from '@src/custom/utils/operator'
 import { ChainId } from '@uniswap/sdk'
-import { addPendingOrder, removeOrder, Order, OrderID, clearOrders, fulfillOrder, OrderStatus } from './actions'
+import { addPendingOrder, removeOrder, Order, clearOrders, fulfillOrder, OrderStatus } from './actions'
 
 export interface OrderObject {
   id: OrderID

--- a/src/custom/state/orders/reducer.ts
+++ b/src/custom/state/orders/reducer.ts
@@ -1,5 +1,5 @@
 import { createReducer, PayloadAction } from '@reduxjs/toolkit'
-import { OrderID } from '@src/custom/utils/operator'
+import { OrderID } from 'utils/operator'
 import { ChainId } from '@uniswap/sdk'
 import { addPendingOrder, removeOrder, Order, clearOrders, fulfillOrder, OrderStatus } from './actions'
 

--- a/src/custom/utils/operator.ts
+++ b/src/custom/utils/operator.ts
@@ -72,7 +72,7 @@ async function _getErrorForBadPostOrderRequest(response: Response): Promise<stri
         break
     }
   } catch (error) {
-    console.error('Error handling a 400 error. Probably could not deserialize the JSON response')
+    console.error('Error handling a 400 error. Likely a problem deserialising the JSON response')
     errorMessage = 'The order was not accepted by the operator'
   }
 

--- a/src/custom/utils/operator.ts
+++ b/src/custom/utils/operator.ts
@@ -107,10 +107,6 @@ export async function postSignedOrder(params: { chainId: ChainId; order: OrderCr
 
   const orderRaw: Omit<OrderCreation, 'kind'> & { kind: string } = {
     ...order,
-    // The API will accept 0x prefix soon. this is temp code
-    sellToken: order.sellToken.toString().substr(2),
-    buyToken: order.buyToken.toString().substr(2),
-    signature: order.signature.substr(2),
     // TODO: The NPM module will use the same structure as the API soon, this is temporal code too
     kind: order.kind === ORDER_KIND_SELL ? 'sell' : 'buy'
   }

--- a/src/custom/utils/operator.ts
+++ b/src/custom/utils/operator.ts
@@ -1,5 +1,5 @@
 import { ChainId } from '@uniswap/sdk'
-import { OrderCreation } from 'utils/signatures'
+import { OrderCreation, ORDER_KIND_SELL } from 'utils/signatures'
 
 /**
  * See Swagger documentation:
@@ -105,11 +105,14 @@ export async function postSignedOrder(params: { chainId: ChainId; order: OrderCr
   const { chainId, order } = params
   console.log('[utils:operator] Post signed order for network', chainId, order)
 
-  const orderRaw: OrderCreation = {
+  const orderRaw: Omit<OrderCreation, 'kind'> & { kind: string } = {
     ...order,
+    // The API will accept 0x prefix soon. this is temp code
     sellToken: order.sellToken.toString().substr(2),
     buyToken: order.buyToken.toString().substr(2),
-    signature: order.signature.substr(2)
+    signature: order.signature.substr(2),
+    // TODO: The NPM module will use the same structure as the API soon, this is temporal code too
+    kind: order.kind === ORDER_KIND_SELL ? 'sell' : 'buy'
   }
 
   // Call API
@@ -121,12 +124,10 @@ export async function postSignedOrder(params: { chainId: ChainId; order: OrderCr
 
   // Handle respose
   if (!response.ok) {
-    console.log('Not OK')
     // Raise an exception
     const errorMessage = await _getErrorForUnsuccessfulPostOrder(response)
     throw new Error(errorMessage)
   }
-  console.log('OK')
 
   const uid = response.json()
   console.log('[util:operator] Success posting the signed order', uid)

--- a/src/custom/utils/operator.ts
+++ b/src/custom/utils/operator.ts
@@ -105,11 +105,18 @@ export async function postSignedOrder(params: { chainId: ChainId; order: OrderCr
   const { chainId, order } = params
   console.log('[utils:operator] Post signed order for network', chainId, order)
 
+  const orderRaw: OrderCreation = {
+    ...order,
+    sellToken: order.sellToken.toString().substr(2),
+    buyToken: order.buyToken.toString().substr(2),
+    signature: order.signature.substr(2)
+  }
+
   // Call API
   const baseUrl = _getApiBaseUrl(chainId)
   const response = await fetch(`${baseUrl}/orders`, {
     ...POST_HEADERS,
-    body: JSON.stringify(order)
+    body: JSON.stringify(orderRaw)
   })
 
   // Handle respose
@@ -117,7 +124,6 @@ export async function postSignedOrder(params: { chainId: ChainId; order: OrderCr
     console.log('Not OK')
     // Raise an exception
     const errorMessage = await _getErrorForUnsuccessfulPostOrder(response)
-    console.error('[util:operator] Error posting the signed order', response.text)
     throw new Error(errorMessage)
   }
   console.log('OK')

--- a/src/custom/utils/operator.ts
+++ b/src/custom/utils/operator.ts
@@ -1,0 +1,121 @@
+import { ChainId } from '@uniswap/sdk'
+import { OrderCreation } from 'utils/signatures'
+
+/**
+ * See Swagger documentation:
+ *    https://protocol-rinkeby.dev.gnosisdev.com/api/
+ */
+const API_BASE_URL: Partial<Record<ChainId, string>> = {
+  [ChainId.MAINNET]: 'https://protocol-rinkeby.dev.gnosisdev.com/api/v2',
+  [ChainId.RINKEBY]: ''
+  // [ChainId.xDAI]: 'https://protocol-xdai.dev.gnosisdev.com/api/v2'
+}
+
+const DEFAULT_HEADERS = {
+  headers: {
+    'Content-Type': 'application/json'
+    // TODO: Maybe add a custom header for the AppId (same as the signing tx)
+  }
+}
+
+const POST_HEADERS = {
+  method: 'POST',
+  ...DEFAULT_HEADERS
+}
+
+/**
+ * Unique identifier for the order, calculated by keccak256(orderDigest, ownerAddress, validTo),
+   where orderDigest = keccak256(orderStruct). bytes32.
+ */
+export type OrderID = string
+
+export interface OrderPostError {
+  errorType: 'MissingOrderData' | 'InvalidSignature' | 'DuplicateOrder' | 'InsufficientFunds'
+  description: string
+}
+
+function _getApiBaseUrl(chainId: ChainId): string {
+  const baseUrl = API_BASE_URL[chainId]
+
+  if (!baseUrl) {
+    throw new Error('Unsupported Network. The operator API is not deployed in the Network ' + chainId)
+  } else {
+    return baseUrl
+  }
+}
+
+async function _getErrorForBadPostOrderRequest(response: Response): Promise<string> {
+  const orderPostError: OrderPostError = await response.json()
+
+  let errorMessage: string
+  switch (orderPostError.errorType) {
+    case 'DuplicateOrder':
+      errorMessage = 'There was another identical order already submitted'
+      break
+
+    case 'InsufficientFunds':
+      errorMessage = "The account doesn't have enough funds"
+      break
+
+    case 'InvalidSignature':
+      errorMessage = 'The order signature is invalid'
+      break
+
+    case 'MissingOrderData':
+      errorMessage = 'The order has missing information'
+      break
+
+    default:
+      console.error('Unknown reason for bad order submission', orderPostError)
+      errorMessage = orderPostError.description
+      break
+  }
+
+  return `The order was refused. ${errorMessage}`
+}
+
+async function _getErrorForUnsuccessfulPostOrder(response: Response): Promise<string> {
+  let errorMessage: string
+  switch (response.status) {
+    case 400:
+      errorMessage = await _getErrorForBadPostOrderRequest(response)
+      break
+
+    case 403:
+      errorMessage = 'The order cannot be accepted. Your account is deny-listed.'
+      break
+
+    case 429:
+      errorMessage = 'The order cannot be accepted. Too many order placements. Please, retry in a minute'
+      break
+
+    case 500:
+    default:
+      errorMessage = 'Error adding an order'
+  }
+  return errorMessage
+}
+
+export async function postSignedOrder(params: { chainId: ChainId; order: OrderCreation }): Promise<OrderID> {
+  const { chainId, order } = params
+  console.log('[utils:operator] Post signed order for network', chainId, order)
+
+  // Call API
+  const baseUrl = _getApiBaseUrl(chainId)
+  const response = await fetch(`${baseUrl}/orders`, {
+    ...POST_HEADERS,
+    body: JSON.stringify(order)
+  })
+
+  // Handle respose
+  if (!response.ok) {
+    // Raise an exception
+    const errorMessage = await _getErrorForUnsuccessfulPostOrder(response)
+    console.error('[util:operator] Error posting the signed order', response.text)
+    throw new Error(errorMessage)
+  }
+
+  const uid = response.json()
+  console.log('[util:operator] Success posting the signed order', uid)
+  return uid
+}

--- a/src/custom/utils/signatures.ts
+++ b/src/custom/utils/signatures.ts
@@ -13,6 +13,14 @@ export interface SignOrderParams {
   order: UnsignedOrder
 }
 
+// posted to /api/v1/orders on Order creation
+// serializable, so no BigNumbers
+//  See https://protocol-rinkeby.dev.gnosisdev.com/api/
+export interface OrderCreation extends UnsignedOrder {
+  // TODO: I commented this because I expect the API and contract to follow the same structure for the order data. confirm and delete this comment
+  signature: string // 65 bytes encoded as hex without `0x` prefix. v + r + s from the spec
+}
+
 // TODO: We cannot make use of the NPM exported enum, see https://babeljs.io/docs/en/babel-plugin-transform-typescript#caveats
 //      use workaround?
 // /**
@@ -67,6 +75,6 @@ export async function signOrder(params: SignOrderParams): Promise<string> {
   const { chainId, signer, order } = params
 
   const domain = _getDomain(chainId)
-  console.log('[signature] signOrder', { domain, order, signer, TYPED_DATA_SIGNING_SCHEME })
+  console.log('[utils:signature] signOrder', { domain, order, signer, TYPED_DATA_SIGNING_SCHEME })
   return signOrderGp(domain, order, signer, TYPED_DATA_SIGNING_SCHEME)
 }


### PR DESCRIPTION
> NOTE: NPM package is incompatible with the current API version, this is why the API don't accept the signed orders. Once contract guys release version, I hope this works as expected.


This PR posts a signed order to the operator. Also handle the possible error responses

Moves the type definitio closer to what I thought it made more sense:
- UUID to the API: It's what they return
- Order structure to the signing

The API call:
- Sends the JSON of the order, including the signature of it
- Handles errors by status code as defined in the Open API doc
- Handles special 40x error, giving a custom message for them

![image](https://user-images.githubusercontent.com/2352112/101895984-8feab400-3ba8-11eb-8c4d-273558271bef.png)
