### PR TITLE
Expired orders logic

### DIFF
--- a/src/custom/state/orders/actions.ts
+++ b/src/custom/state/orders/actions.ts
@@ -13,7 +13,8 @@ export interface OrderCreation extends UnsignedOrder {
 
 export enum OrderStatus {
   PENDING = 'pending',
-  FULFILLED = 'fulfilled'
+  FULFILLED = 'fulfilled',
+  EXPIRED = 'expired'
 }
 
 // used internally by dapp
@@ -50,6 +51,7 @@ export const removeOrder = createAction<{ id: OrderID; chainId: ChainId }>('orde
 export const fulfillOrder = createAction<{ id: OrderID; chainId: ChainId; fulfillmentTime: string }>(
   'order/fulfillOrder'
 )
+export const expireOrder = createAction<{ id: OrderID; chainId: ChainId }>('order/expireOrder')
 export const clearOrders = createAction<{ chainId: ChainId }>('order/clearOrders')
 
 export const updateLastCheckedBlock = createAction<{ chainId: ChainId; lastCheckedBlock: number }>(

--- a/src/custom/state/orders/hooks.ts
+++ b/src/custom/state/orders/hooks.ts
@@ -10,7 +10,8 @@ import {
   fulfillOrder,
   Order,
   OrderID,
-  updateLastCheckedBlock
+  updateLastCheckedBlock,
+  expireOrder
 } from './actions'
 import { OrdersState, PartialOrdersMap } from './reducer'
 import { isTruthy } from 'utils/misc'
@@ -31,6 +32,7 @@ interface GetRemoveOrderParams {
 type GetOrdersParams = Partial<Pick<GetRemoveOrderParams, 'chainId'>>
 type ClearOrdersParams = Pick<GetRemoveOrderParams, 'chainId'>
 type GetLastCheckedBlockParams = GetOrdersParams
+type ExpireOrderParams = GetRemoveOrderParams
 
 interface UpdateLastCheckedBlockParams extends ClearOrdersParams {
   lastCheckedBlock: number
@@ -39,6 +41,7 @@ interface UpdateLastCheckedBlockParams extends ClearOrdersParams {
 type AddOrderCallback = (addOrderParams: AddPendingOrderParams) => void
 type RemoveOrderCallback = (removeOrderParams: GetRemoveOrderParams) => void
 type FulfillOrderCallback = (fulfillOrderParams: FulfillOrderParams) => void
+type ExpireOrderCallback = (fulfillOrderParams: ExpireOrderParams) => void
 type ClearOrdersCallback = (clearOrdersParams: ClearOrdersParams) => void
 type UpdateLastCheckedBlockCallback = (updateLastCheckedBlockParams: UpdateLastCheckedBlockParams) => void
 
@@ -47,7 +50,7 @@ export const useOrder = ({ id, chainId }: GetRemoveOrderParams): Order | undefin
     const orders = state.orders[chainId]
 
     if (!orders) return undefined
-    return orders?.fulfilled[id]?.order || orders?.pending[id]?.order
+    return orders?.fulfilled[id]?.order || orders?.pending[id]?.order || orders?.expired[id]?.order
   })
 }
 
@@ -59,6 +62,7 @@ export const useOrders = ({ chainId }: GetOrdersParams): Order[] => {
 
     const allOrders = Object.values(state.fulfilled)
       .concat(Object.values(state.pending))
+      .concat(Object.values(state.expired))
       .map(orderObject => orderObject?.order)
       .filter(isTruthy)
     return allOrders
@@ -95,6 +99,21 @@ export const useFulfilledOrders = ({ chainId }: GetOrdersParams): Order[] => {
   }, [state])
 }
 
+export const useExpiredOrders = ({ chainId }: GetOrdersParams): Order[] => {
+  const state = useSelector<AppState, PartialOrdersMap | undefined>(
+    state => chainId && state.orders?.[chainId]?.expired
+  )
+
+  return useMemo(() => {
+    if (!state) return []
+
+    const allOrders = Object.values(state)
+      .map(orderObject => orderObject?.order)
+      .filter(isTruthy)
+    return allOrders
+  }, [state])
+}
+
 export const useAddPendingOrder = (): AddOrderCallback => {
   const dispatch = useDispatch<AppDispatch>()
   return useCallback((addOrderParams: AddPendingOrderParams) => dispatch(addPendingOrder(addOrderParams)), [dispatch])
@@ -103,6 +122,11 @@ export const useAddPendingOrder = (): AddOrderCallback => {
 export const useFulfillOrder = (): FulfillOrderCallback => {
   const dispatch = useDispatch<AppDispatch>()
   return useCallback((fulfillOrderParams: FulfillOrderParams) => dispatch(fulfillOrder(fulfillOrderParams)), [dispatch])
+}
+
+export const useExpireOrder = (): ExpireOrderCallback => {
+  const dispatch = useDispatch<AppDispatch>()
+  return useCallback((expireOrderParams: ExpireOrderParams) => dispatch(expireOrder(expireOrderParams)), [dispatch])
 }
 
 export const useRemoveOrder = (): RemoveOrderCallback => {

--- a/src/custom/state/orders/mocks.ts
+++ b/src/custom/state/orders/mocks.ts
@@ -55,7 +55,7 @@ const generateOrder = ({ owner, sellToken, buyToken }: GenerateOrderParams): Ord
 
   const summary = `Order ${kind.toUpperCase()} ${(sellAmount / 10 ** sellToken.decimals).toFixed(2)} ${
     sellToken.symbol
-  } for ${(buyAmount / 10 ** buyToken.decimals).toFixed(2)} ${buyToken.symbol} fulfilled`
+  } for ${(buyAmount / 10 ** buyToken.decimals).toFixed(2)} ${buyToken.symbol}`
 
   return {
     id: generateOrderId(orderN), // Unique identifier for the order: 56 bytes encoded as hex without 0x
@@ -67,8 +67,8 @@ const generateOrder = ({ owner, sellToken, buyToken }: GenerateOrderParams): Ord
     buyToken: buyToken.address.replace('0x', ''), // address, without '0x' prefix
     sellAmount: sellAmount.toString(10), // in atoms
     buyAmount: buyAmount.toString(10), // in atoms
-    // 4 - 6min
-    validTo: Date.now() / 1000 + randomIntInRangeExcept(240, 360), // uint32. unix timestamp, seconds, use new Date(validTo * 1000)
+    // 20sec - 4min
+    validTo: Date.now() / 1000 + randomIntInRangeExcept(20, 240), // uint32. unix timestamp, seconds, use new Date(validTo * 1000)
     appData: 1, // arbitrary identifier sent along with the order
     feeAmount: (1e18).toString(), // in atoms
     kind,
@@ -124,7 +124,7 @@ const useAddOrdersOnMount = (minPendingOrders = 5) => {
   }, [account, addOrder, chainId, library, lists, minPendingOrders])
 }
 
-const useFulfillOrdersRandomly = (interval = 20000 /* ms */) => {
+const useFulfillOrdersRandomly = (interval = 30000 /* ms */) => {
   const { chainId } = useActiveWeb3React()
   const pendingOrders = usePendingOrders({ chainId })
 
@@ -153,10 +153,10 @@ const useFulfillOrdersRandomly = (interval = 20000 /* ms */) => {
             txn: {
               hash: randomOrder.id,
               success: true,
-              summary: randomOrder.summary || `Order ${randomOrder.id} was traded`
+              summary: randomOrder.summary + ' fulfilled' || `Order ${randomOrder.id} was traded`
             }
           },
-          randomOrder.id
+          randomOrder.id + '_fulfilled'
         )
       })
     }

--- a/src/custom/state/orders/updater.ts
+++ b/src/custom/state/orders/updater.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import { useDispatch, batch } from 'react-redux'
 import { useActiveWeb3React } from 'hooks'
 import { useAddPopup, useBlockNumber } from 'state/application/hooks'
@@ -7,7 +7,7 @@ import { fulfillOrder } from './actions'
 import { utils } from 'ethers'
 import { Web3Provider } from '@ethersproject/providers'
 import { Log, Filter } from '@ethersproject/abstract-provider'
-import { useLastCheckedBlock } from './hooks'
+import { useLastCheckedBlock, usePendingOrders, useExpireOrder } from './hooks'
 import { updateLastCheckedBlock } from './actions'
 // import { PartialOrdersMap } from './reducer'
 
@@ -227,6 +227,62 @@ export function EventUpdater(): null {
   //     library.off(TransferEventTopics, listener)
   //   }
   // }, [chainId, library])
+
+  return null
+}
+
+const CHECK_EXPIRED_ORDERS_INTERVAL = 10000 // 10 sec
+
+export function ExpiredOrdersWatcher(): null {
+  const { chainId } = useActiveWeb3React()
+
+  const expireOrder = useExpireOrder()
+
+  const pendingOrders = usePendingOrders({ chainId })
+
+  // ref, so we don't rerun useEffect
+  const pendingOrdersRef = useRef(pendingOrders)
+  pendingOrdersRef.current = pendingOrders
+
+  // for displaying expired orders
+  const addPopup = useAddPopup()
+
+  useEffect(() => {
+    if (!chainId) return
+
+    const checkForExpiredOrders = () => {
+      // no more pending orders
+      // but don't clearInterval so we can restart when there are new orders
+      if (pendingOrdersRef.current.length === 0) return
+
+      const now = new Date()
+      const expiredOrders = pendingOrdersRef.current.filter(order => {
+        // validTo is either a Date or unix timestamp in seconds
+        const validTo = typeof order.validTo === 'number' ? new Date(order.validTo * 1000) : order.validTo
+
+        return validTo < now
+      })
+
+      expiredOrders.forEach(order => {
+        expireOrder({ chainId, id: order.id })
+
+        addPopup(
+          {
+            txn: {
+              hash: order.id,
+              success: false,
+              summary: order.summary + ' expired' || `Order ${order.id} expired`
+            }
+          },
+          order.id + '_expired' // to differentiate further
+        )
+      })
+    }
+
+    const intervalId = setInterval(checkForExpiredOrders, CHECK_EXPIRED_ORDERS_INTERVAL)
+
+    return () => clearInterval(intervalId)
+  }, [chainId, expireOrder, addPopup])
 
   return null
 }

--- a/src/custom/state/orders/updater.ts
+++ b/src/custom/state/orders/updater.ts
@@ -263,19 +263,21 @@ export function ExpiredOrdersWatcher(): null {
         return validTo < now
       })
 
-      expiredOrders.forEach(order => {
-        expireOrder({ chainId, id: order.id })
+      batch(() => {
+        expiredOrders.forEach(order => {
+          expireOrder({ chainId, id: order.id })
 
-        addPopup(
-          {
-            txn: {
-              hash: order.id,
-              success: false,
-              summary: order.summary + ' expired' || `Order ${order.id} expired`
-            }
-          },
-          order.id + '_expired' // to differentiate further
-        )
+          addPopup(
+            {
+              txn: {
+                hash: order.id,
+                success: false,
+                summary: order.summary + ' expired' || `Order ${order.id} expired`
+              }
+            },
+            order.id + '_expired' // to differentiate further
+          )
+        })
       })
     }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,6 +16,7 @@ import MulticallUpdater from './state/multicall/updater'
 import TransactionUpdater from './state/transactions/updater'
 import UserUpdater from './state/user/updater'
 // import { EventUpdater } from 'state/orders/updater'
+import { ExpiredOrdersWatcher } from 'state/orders/updater'
 import { EventUpdater } from 'state/orders/mocks'
 import ThemeProvider, { FixedGlobalStyle, ThemedGlobalStyle } from 'theme'
 import getLibrary from './utils/getLibrary'
@@ -52,6 +53,7 @@ function Updaters() {
       <TransactionUpdater />
       <MulticallUpdater />
       <EventUpdater />
+      <ExpiredOrdersWatcher />
     </>
   )
 }


### PR DESCRIPTION
1. Checks on interval if any of `pendingOrders` has expired
2. Moves them to `orders.expired` state
3. Shows popup

Alternative to the interval way would be to `setTimeout` till the closest `Order.validTo`, and then set again to next. But that way we'd also have to recalc the closest order when `pendingOrders` get updated. Will be ugly and less lightweight with `clearTimeout` on each recalc. And would have to `clearTimeout` again if order gets fulfilled, and then recalc, ugh...

![localhost_3000_ (4)](https://user-images.githubusercontent.com/5121491/102100002-fcc8ad00-3e39-11eb-9370-fa5adefac545.png)

Travis will break because of dynamic import, it's expected