### PR TITLE
Refactor postorders to its own util

### DIFF
--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -1,5 +1,8 @@
 import { ChainId } from '@uniswap/sdk'
 
+// TODO: Load app Id
+export const APP_ID = 0
+
 // TODO: The addresses will be exported as plain JSON file in the future
 
 // reexport all Uniswap constants everything

--- a/src/custom/hooks/useSwapCallback.ts
+++ b/src/custom/hooks/useSwapCallback.ts
@@ -2,124 +2,17 @@ import { SwapCallbackState } from '@src/hooks/useSwapCallback'
 import { INITIAL_ALLOWED_SLIPPAGE } from 'constants/index'
 
 // import { useSwapCallback as useSwapCallbackUniswap } from '@src/hooks/useSwapCallback'
-import { ChainId, Percent, Trade, TradeType } from '@uniswap/sdk'
+import { Percent, Trade } from '@uniswap/sdk'
 import { useActiveWeb3React } from '@src/hooks'
 import useENS from '@src/hooks/useENS'
 import { useMemo } from 'react'
 import useTransactionDeadline from '@src/hooks/useTransactionDeadline'
-import { BigNumber, Signer } from 'ethers'
-import { isAddress, shortenAddress } from '@src/utils'
-import { AddPendingOrderParams, OrderStatus, OrderKind } from 'state/orders/actions'
-import { useAddPendingOrder } from 'state/orders/hooks'
-import { signOrder, UnsignedOrder } from 'utils/signatures'
-import { getFeeQuote as getFeeInformation, postSignedOrder } from 'utils/operator'
-import { getFeeAmount } from 'utils/fee'
+import { BigNumber } from 'ethers'
 
-interface PostOrderParams {
-  account: string
-  chainId: ChainId
-  signer: Signer
-  trade: Trade
-  validTo: number
-  recipient: string
-  recipientAddressOrName: string | null
-  addPendingOrder: (order: AddPendingOrderParams) => void
-}
+import { useAddPendingOrder } from 'state/orders/hooks'
+import { postOrder } from '../utils/trade'
 
 const MAX_VALID_TO_EPOCH = BigNumber.from('0xFFFFFFFF').toNumber() // Max uint32 (Feb 07 2106 07:28:15 GMT+0100)
-const DEFAULT_APP_ID = 0
-
-function _getSummary(params: PostOrderParams): string {
-  const { trade, account, recipient, recipientAddressOrName } = params
-
-  const inputSymbol = trade.inputAmount.currency.symbol
-  const outputSymbol = trade.outputAmount.currency.symbol
-  const inputAmount = trade.inputAmount.toSignificant(3)
-  const outputAmount = trade.outputAmount.toSignificant(3)
-
-  const base = `Swap ${inputAmount} ${inputSymbol} for ${outputAmount} ${outputSymbol}`
-
-  if (recipient === account) {
-    return base
-  } else {
-    const toAddress =
-      recipientAddressOrName && isAddress(recipientAddressOrName)
-        ? shortenAddress(recipientAddressOrName)
-        : recipientAddressOrName
-
-    return `${base} to ${toAddress}`
-  }
-}
-
-async function _postOrder(params: PostOrderParams): Promise<string> {
-  const { addPendingOrder, chainId, trade, validTo, account, signer } = params
-  const { inputAmount, outputAmount } = trade
-
-  const path = trade.route.path
-  const sellToken = path[0]
-  const buyToken = path[path.length - 1]
-  const sellAmount = inputAmount.raw.toString(10)
-  const buyAmount = outputAmount.raw.toString(10)
-
-  // TODO: This might disappear, and just take the state from the state after the fees PRs are merged
-  //  we assume, the solvers will try to satisfy the price, and this fee is just a minimal fee.
-  // Get Fee
-  const { feeRatio, minimalFee } = await getFeeInformation(chainId, sellToken.address)
-  const feeAmount = getFeeAmount({
-    sellAmount: sellAmount,
-    feeRatio,
-    minimalFee
-  })
-
-  // Prepare order
-  const summary = _getSummary(params)
-  const unsignedOrder: UnsignedOrder = {
-    sellToken: sellToken.address,
-    buyToken: buyToken.address,
-    sellAmount,
-    buyAmount,
-    validTo,
-    appData: DEFAULT_APP_ID, // TODO: Add appData by env var
-    feeAmount,
-    kind: trade.tradeType === TradeType.EXACT_INPUT ? OrderKind.SELL : OrderKind.BUY,
-    partiallyFillable: false // Always fill or kill
-  }
-
-  const signature = await signOrder({
-    chainId,
-    signer,
-    order: unsignedOrder
-  })
-  const creationTime = new Date().toISOString()
-
-  // Call API
-  const orderId = await postSignedOrder({
-    chainId,
-    order: {
-      ...unsignedOrder,
-      signature
-    }
-  })
-
-  // Update the state
-  addPendingOrder({
-    chainId,
-    id: orderId,
-    order: {
-      ...unsignedOrder,
-      id: orderId,
-      owner: account,
-      creationTime,
-      signature,
-      status: OrderStatus.PENDING,
-      summary
-    }
-  })
-
-  console.log('[useSwapCallback] TODO: Add summary also to new pendingOrder', summary)
-
-  return orderId
-}
 
 // returns a function that will execute a swap, if the parameters are all valid
 // and the user has approved the slippage adjusted input amount for the trade
@@ -175,7 +68,7 @@ export function useSwapCallback(
             chainId
           }
         )
-        return _postOrder({
+        return postOrder({
           account,
           chainId,
           trade,

--- a/src/custom/utils/trade.ts
+++ b/src/custom/utils/trade.ts
@@ -1,0 +1,112 @@
+import { ChainId, Trade, TradeType } from '@uniswap/sdk'
+import { isAddress, shortenAddress } from '@src/utils'
+import { AddPendingOrderParams, OrderStatus, OrderKind } from 'state/orders/actions'
+
+import { signOrder, UnsignedOrder } from 'utils/signatures'
+import { getFeeQuote as getFeeInformation, postSignedOrder } from 'utils/operator'
+import { getFeeAmount } from 'utils/fee'
+import { Signer } from 'ethers'
+import { APP_ID } from 'constants/index'
+
+export interface PostOrderParams {
+  account: string
+  chainId: ChainId
+  signer: Signer
+  trade: Trade
+  validTo: number
+  recipient: string
+  recipientAddressOrName: string | null
+  addPendingOrder: (order: AddPendingOrderParams) => void
+}
+
+function _getSummary(params: PostOrderParams): string {
+  const { trade, account, recipient, recipientAddressOrName } = params
+
+  const inputSymbol = trade.inputAmount.currency.symbol
+  const outputSymbol = trade.outputAmount.currency.symbol
+  const inputAmount = trade.inputAmount.toSignificant(3)
+  const outputAmount = trade.outputAmount.toSignificant(3)
+
+  const base = `Swap ${inputAmount} ${inputSymbol} for ${outputAmount} ${outputSymbol}`
+
+  if (recipient === account) {
+    return base
+  } else {
+    const toAddress =
+      recipientAddressOrName && isAddress(recipientAddressOrName)
+        ? shortenAddress(recipientAddressOrName)
+        : recipientAddressOrName
+
+    return `${base} to ${toAddress}`
+  }
+}
+
+export async function postOrder(params: PostOrderParams): Promise<string> {
+  const { addPendingOrder, chainId, trade, validTo, account, signer } = params
+  const { inputAmount, outputAmount } = trade
+
+  const path = trade.route.path
+  const sellToken = path[0]
+  const buyToken = path[path.length - 1]
+  const sellAmount = inputAmount.raw.toString(10)
+  const buyAmount = outputAmount.raw.toString(10)
+
+  // TODO: This might disappear, and just take the state from the state after the fees PRs are merged
+  //  we assume, the solvers will try to satisfy the price, and this fee is just a minimal fee.
+  // Get Fee
+  const { feeRatio, minimalFee } = await getFeeInformation(chainId, sellToken.address)
+  const feeAmount = getFeeAmount({
+    sellAmount: sellAmount,
+    feeRatio,
+    minimalFee
+  })
+
+  // Prepare order
+  const summary = _getSummary(params)
+  const unsignedOrder: UnsignedOrder = {
+    sellToken: sellToken.address,
+    buyToken: buyToken.address,
+    sellAmount,
+    buyAmount,
+    validTo,
+    appData: APP_ID, // TODO: Add appData by env var
+    feeAmount,
+    kind: trade.tradeType === TradeType.EXACT_INPUT ? OrderKind.SELL : OrderKind.BUY,
+    partiallyFillable: false // Always fill or kill
+  }
+
+  const signature = await signOrder({
+    chainId,
+    signer,
+    order: unsignedOrder
+  })
+  const creationTime = new Date().toISOString()
+
+  // Call API
+  const orderId = await postSignedOrder({
+    chainId,
+    order: {
+      ...unsignedOrder,
+      signature
+    }
+  })
+
+  // Update the state
+  addPendingOrder({
+    chainId,
+    id: orderId,
+    order: {
+      ...unsignedOrder,
+      id: orderId,
+      owner: account,
+      creationTime,
+      signature,
+      status: OrderStatus.PENDING,
+      summary
+    }
+  })
+
+  console.log('[useSwapCallback] TODO: Add summary also to new pendingOrder', summary)
+
+  return orderId
+}


### PR DESCRIPTION
Small PR that just removes the `postOrder` logic from the hook and moves it to a util.

This way, the hook is simpler, and the logic easier to maintain and test

> note: I'm starting a new waterfall witht his :P it would be nice to merge soon