### PR TITLE
Transactions list (extend original)

### DIFF
--- a/src/components/AccountDetails/index.tsx
+++ b/src/components/AccountDetails/index.tsx
@@ -7,7 +7,7 @@ import { clearAllTransactions } from '../../state/transactions/actions'
 import { shortenAddress } from '../../utils'
 import { AutoRow } from '../Row'
 import Copy from './Copy'
-import Transaction from './Transaction'
+import Transaction from 'components/AccountDetails/Transaction'
 
 import { SUPPORTED_WALLETS } from '../../constants'
 import { ReactComponent as Close } from '../../assets/images/x.svg'

--- a/src/custom/components/AccountDetails/Transaction.tsx
+++ b/src/custom/components/AccountDetails/Transaction.tsx
@@ -50,9 +50,9 @@ function getActivitySummary({
 }
 
 // override the href prop when we dont want a clickable row
-const TransactionState = styled(OldTransactionState).attrs((props): { href?: string } => ({
-  href: props.href
-}))``
+const TransactionState = styled(OldTransactionState).attrs((props): { href?: string; isMeta?: boolean } => props)`
+  ${(props): string | false => !!props.isMeta && `pointer-events: none; cursor: none;`}
+`
 
 export default function Transaction({ hash: id }: { hash: string }) {
   const { chainId } = useActiveWeb3React()
@@ -71,6 +71,8 @@ export default function Transaction({ hash: id }: { hash: string }) {
         href={!isOrder ? getEtherscanLink(chainId, id, 'transaction') : undefined}
         pending={pending}
         success={success}
+        // prevent cursor on meta tx
+        isMeta={isOrder && pending}
       >
         <RowFixed>
           {activity && (

--- a/src/custom/components/AccountDetails/Transaction.tsx
+++ b/src/custom/components/AccountDetails/Transaction.tsx
@@ -1,0 +1,68 @@
+import React from 'react'
+import { CheckCircle, Triangle } from 'react-feather'
+
+import { useActiveWeb3React } from 'hooks'
+import { getEtherscanLink } from 'utils'
+import { useAllTransactions } from 'state/transactions/hooks'
+import { RowFixed } from 'components/Row'
+import Loader from 'components/Loader'
+import { useAllOrders } from 'custom/state/orders/hooks'
+import { TransactionDetails } from 'state/transactions/reducer'
+import { Order, OrderStatus } from 'custom/state/orders/actions'
+import { TransactionWrapper, TransactionState, TransactionStatusText, IconWrapper } from './TransactionMod'
+import Pill from '../Pill'
+
+function determinePillColour(success: boolean, type: 'order' | 'transaction') {
+  const isPendingOrder = !success && type === 'order',
+    isFulfilledOrder = success && type === 'order',
+    isPendingTx = !success && type === 'transaction',
+    isFulfilledTx = success && type === 'transaction'
+
+  if (isPendingOrder) return 'violet'
+  else if (isFulfilledOrder) return 'lightgreen'
+  else if (isPendingTx) return 'lightblue'
+  else if (isFulfilledTx) return 'darkgreen'
+  else return 'transparent'
+}
+
+export default function Transaction({ hash }: { hash: string }) {
+  const { chainId } = useActiveWeb3React()
+  const allTransactions = useAllTransactions()
+  const allOrders = useAllOrders({ chainId })
+
+  const tx = allTransactions?.[hash]
+  const order = allOrders?.[hash]?.order
+
+  if ((!tx && !order) || !chainId) return null
+
+  let activity: TransactionDetails | Order, summary, pending, success, type: 'order' | 'transaction'
+  if (!tx && order) {
+    activity = order
+    summary = activity?.summary
+    pending = activity?.status === OrderStatus.PENDING
+    success = !pending && activity && activity?.status === OrderStatus.FULFILLED
+    type = 'order'
+  } else {
+    activity = tx
+    summary = tx?.summary
+    pending = !tx?.receipt
+    success = !pending && tx && (tx.receipt?.status === 1 || typeof tx.receipt?.status === 'undefined')
+    type = 'transaction'
+  }
+
+  return (
+    <TransactionWrapper>
+      <TransactionState href={getEtherscanLink(chainId, hash, 'transaction')} pending={pending} success={success}>
+        <RowFixed>
+          {activity && (
+            <Pill bgColor={determinePillColour(success, type)}>{(success ? 'Confirmed ' : 'Pending ') + type}</Pill>
+          )}
+          <TransactionStatusText>{summary ?? hash} ↗</TransactionStatusText>
+        </RowFixed>
+        <IconWrapper pending={pending} success={success}>
+          {pending ? <Loader /> : success ? <CheckCircle size="16" /> : <Triangle size="16" />}
+        </IconWrapper>
+      </TransactionState>
+    </TransactionWrapper>
+  )
+}

--- a/src/custom/components/AccountDetails/Transaction.tsx
+++ b/src/custom/components/AccountDetails/Transaction.tsx
@@ -18,10 +18,10 @@ function determinePillColour(success: boolean, type: 'order' | 'transaction') {
     isPendingTx = !success && type === 'transaction',
     isFulfilledTx = success && type === 'transaction'
 
-  if (isPendingOrder) return 'violet'
-  else if (isFulfilledOrder) return 'lightgreen'
-  else if (isPendingTx) return 'lightblue'
-  else if (isFulfilledTx) return 'darkgreen'
+  if (isPendingOrder) return '#8958FF'
+  else if (isFulfilledOrder) return '#27AE60'
+  else if (isPendingTx) return '#ff58e8'
+  else if (isFulfilledTx) return '27AE60'
   else return 'transparent'
 }
 
@@ -55,7 +55,9 @@ export default function Transaction({ hash }: { hash: string }) {
       <TransactionState href={getEtherscanLink(chainId, hash, 'transaction')} pending={pending} success={success}>
         <RowFixed>
           {activity && (
-            <Pill bgColor={determinePillColour(success, type)}>{(success ? 'Confirmed ' : 'Pending ') + type}</Pill>
+            <Pill color="#fff" bgColor={determinePillColour(success, type)}>
+              {type}
+            </Pill>
           )}
           <TransactionStatusText>{summary ?? hash} ↗</TransactionStatusText>
         </RowFixed>

--- a/src/custom/components/AccountDetails/TransactionMod.tsx
+++ b/src/custom/components/AccountDetails/TransactionMod.tsx
@@ -1,0 +1,62 @@
+import React from 'react'
+import styled from 'styled-components'
+import { CheckCircle, Triangle } from 'react-feather'
+
+import { useActiveWeb3React } from 'hooks'
+import { getEtherscanLink } from 'utils'
+import { ExternalLink } from 'theme'
+import { useAllTransactions } from 'state/transactions/hooks'
+import { RowFixed } from 'components/Row'
+import Loader from 'components/Loader'
+
+export const TransactionWrapper = styled.div``
+
+export const TransactionStatusText = styled.div`
+  margin-right: 0.5rem;
+  display: flex;
+  align-items: center;
+  :hover {
+    text-decoration: underline;
+  }
+`
+
+export const TransactionState = styled(ExternalLink)<{ pending: boolean; success?: boolean }>`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  text-decoration: none !important;
+  border-radius: 0.5rem;
+  padding: 0.25rem 0rem;
+  font-weight: 500;
+  font-size: 0.825rem;
+  color: ${({ theme }) => theme.primary1};
+`
+
+export const IconWrapper = styled.div<{ pending: boolean; success?: boolean }>`
+  color: ${({ pending, success, theme }) => (pending ? theme.primary1 : success ? theme.green1 : theme.red1)};
+`
+
+export default function Transaction({ hash }: { hash: string }) {
+  const { chainId } = useActiveWeb3React()
+  const allTransactions = useAllTransactions()
+
+  const tx = allTransactions?.[hash]
+  const summary = tx?.summary
+  const pending = !tx?.receipt
+  const success = !pending && tx && (tx.receipt?.status === 1 || typeof tx.receipt?.status === 'undefined')
+
+  if (!chainId) return null
+
+  return (
+    <TransactionWrapper>
+      <TransactionState href={getEtherscanLink(chainId, hash, 'transaction')} pending={pending} success={success}>
+        <RowFixed>
+          <TransactionStatusText>{summary ?? hash} ↗</TransactionStatusText>
+        </RowFixed>
+        <IconWrapper pending={pending} success={success}>
+          {pending ? <Loader /> : success ? <CheckCircle size="16" /> : <Triangle size="16" />}
+        </IconWrapper>
+      </TransactionState>
+    </TransactionWrapper>
+  )
+}

--- a/src/custom/components/Pill/index.tsx
+++ b/src/custom/components/Pill/index.tsx
@@ -1,12 +1,16 @@
 import styled from 'styled-components'
 
-const Pill = styled.strong<{ color?: string; bgColor?: string }>`
+const Pill = styled.strong<{ color?: string; bgColor?: string; minWidth?: string }>`
   padding: 0.2rem 0.4rem;
   border-radius: 1rem;
   color: ${(props): string => props.color || 'inherit'};
   background-color: ${(props): string => props.bgColor || 'transparent'};
   margin-right: 0.5rem;
   font-size: smaller;
+  font-weight: 600;
+  text-align: center;
+  text-transform: uppercase;
   white-space: nowrap;
+  min-width: ${(props): string => props.minWidth || 'unset'};
 `
 export default Pill

--- a/src/custom/components/Pill/index.tsx
+++ b/src/custom/components/Pill/index.tsx
@@ -1,0 +1,11 @@
+import styled from 'styled-components'
+
+const Pill = styled.strong<{ bgColor: string }>`
+  padding: 0.2rem 0.4rem;
+  border-radius: 1rem;
+  background-color: ${(props): string => props.bgColor};
+  margin-right: 0.5rem;
+  font-size: smaller;
+  white-space: nowrap;
+`
+export default Pill

--- a/src/custom/components/Pill/index.tsx
+++ b/src/custom/components/Pill/index.tsx
@@ -1,9 +1,10 @@
 import styled from 'styled-components'
 
-const Pill = styled.strong<{ bgColor: string }>`
+const Pill = styled.strong<{ color?: string; bgColor?: string }>`
   padding: 0.2rem 0.4rem;
   border-radius: 1rem;
-  background-color: ${(props): string => props.bgColor};
+  color: ${(props): string => props.color || 'inherit'};
+  background-color: ${(props): string => props.bgColor || 'transparent'};
   margin-right: 0.5rem;
   font-size: smaller;
   white-space: nowrap;


### PR DESCRIPTION
Waterfalls into #60 

Extends `Transactions.tsx` component to deal with pending/confirmed Transactions/Orders

Adds a `Pill` component to `custom` and rendered inside `Transactions`

Extended components: `Transactions` > `TransactionsMod` 

Sample activities list:
![Screenshot from 2020-12-15 16-04-04](https://user-images.githubusercontent.com/21335563/102236101-5f31b400-3ef3-11eb-8b1a-18c11c165bb6.png)
