### PR TITLE
Improve message in case of error getting the fee

### DIFF
--- a/src/custom/utils/operator.ts
+++ b/src/custom/utils/operator.ts
@@ -149,11 +149,17 @@ export async function getFeeQuote(chainId: ChainId, tokenAddress: string): Promi
   // TODO: Let see if we can incorporate the PRs from the Fee, where they cache stuff and keep it in sync using redux.
   // if that part is delayed or need more review, we can easily add the cache in this file (we check expiration and cache here)
 
-  const response = await _get(chainId, `/tokens/${tokenAddress}/fee`)
-
-  if (!response.ok) {
-    throw new Error('Error getting the fee')
+  let response: Response | undefined
+  try {
+    const responseMaybeOk = await _get(chainId, `/tokens/${tokenAddress}/fee`)
+    response = responseMaybeOk.ok ? responseMaybeOk : undefined
+  } catch (error) {
+    // do nothing
   }
 
-  return response.json()
+  if (!response) {
+    throw new Error('Error getting the fee')
+  } else {
+    return response.json()
+  }
 }


### PR DESCRIPTION
Tiny PR just to improve the message in case the operator returns a error. The fetch request can reject, as we can see in #62

I would just hint the user were was the issue 
![image](https://user-images.githubusercontent.com/2352112/102237834-5c37c300-3ef5-11eb-950b-d5436ed2b404.png)

The error nows says always `Error getting the fee`