### PR TITLE
[FIX] Clear All button in Transactions list

### DIFF
--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -14,7 +14,7 @@ import usePrevious from '../../hooks/usePrevious'
 import { ApplicationModal } from '../../state/application/actions'
 import { useModalOpen, useWalletModalToggle } from '../../state/application/hooks'
 import { ExternalLink } from 'theme'
-import AccountDetails from '../AccountDetails'
+import AccountDetails from 'components/AccountDetails'
 
 import Modal from '../Modal'
 import Option from './Option'

--- a/src/custom/components/AccountDetails/AccountDetailsMod.tsx
+++ b/src/custom/components/AccountDetails/AccountDetailsMod.tsx
@@ -1,27 +1,27 @@
-import React, { useCallback, useContext } from 'react'
-import { batch, useDispatch } from 'react-redux'
-import styled, { ThemeContext } from 'styled-components'
-import { useActiveWeb3React } from 'hooks'
-import { AppDispatch } from 'state'
-import { clearAllTransactions } from 'state/transactions/actions'
-import { shortenAddress } from 'utils'
-import { AutoRow } from 'components/Row'
-import Copy from 'components/AccountDetails/Copy'
+import React /* , { useCallback, useContext } */ from 'react'
+// import { batch, useDispatch } from 'react-redux'
+import styled /* , { ThemeContext } */ from 'styled-components'
+// import { useActiveWeb3React } from 'hooks'
+// import { AppDispatch } from 'state'
+// import { clearAllTransactions } from 'state/transactions/actions'
+// import { shortenAddress } from 'utils'
+// import { AutoRow } from 'components/Row'
+// import Copy from 'components/AccountDetails/Copy'
 import Transaction from 'components/AccountDetails/Transaction'
 
-import { SUPPORTED_WALLETS } from 'constants/index'
+// import { SUPPORTED_WALLETS } from 'constants/index'
 import { ReactComponent as Close } from 'assets/images/x.svg'
-import { getEtherscanLink } from 'utils'
-import { injected, walletconnect, walletlink, fortmatic, portis } from 'connectors'
-import CoinbaseWalletIcon from 'assets/images/coinbaseWalletIcon.svg'
-import WalletConnectIcon from 'assets/images/walletConnectIcon.svg'
-import FortmaticIcon from 'assets/images/fortmaticIcon.png'
-import PortisIcon from 'assets/images/portisIcon.png'
-import Identicon from 'components/Identicon'
-import { ButtonSecondary } from '../Button'
-import { ExternalLink as LinkIcon } from 'react-feather'
-import { ExternalLink, LinkStyledButton, TYPE } from 'theme'
-import { clearOrders } from 'state/orders/actions'
+// import { getEtherscanLink } from 'utils'
+// import { injected, walletconnect, walletlink, fortmatic, portis } from 'connectors'
+// import CoinbaseWalletIcon from 'assets/images/coinbaseWalletIcon.svg'
+// import WalletConnectIcon from 'assets/images/walletConnectIcon.svg'
+// import FortmaticIcon from 'assets/images/fortmaticIcon.png'
+// import PortisIcon from 'assets/images/portisIcon.png'
+// import Identicon from 'components/Identicon'
+import { ButtonSecondary } from 'components/Button'
+// import { ExternalLink as LinkIcon } from 'react-feather'
+import { ExternalLink /* , LinkStyledButton, TYPE */ } from 'theme'
+// import { clearOrders } from 'state/orders/actions'
 
 export const HeaderRow = styled.div`
   ${({ theme }) => theme.flexRowNoWrap};
@@ -219,199 +219,199 @@ export interface AccountDetailsProps {
   openOptions: () => void
 }
 
-export default function AccountDetails({
-  toggleWalletModal,
-  pendingTransactions,
-  confirmedTransactions,
-  ENSName,
-  openOptions
-}: AccountDetailsProps) {
-  const { chainId, account, connector } = useActiveWeb3React()
-  const theme = useContext(ThemeContext)
-  const dispatch = useDispatch<AppDispatch>()
+// export default function AccountDetails({
+//   toggleWalletModal,
+//   pendingTransactions,
+//   confirmedTransactions,
+//   ENSName,
+//   openOptions
+// }: AccountDetailsProps) {
+//   const { chainId, account, connector } = useActiveWeb3React()
+//   const theme = useContext(ThemeContext)
+//   const dispatch = useDispatch<AppDispatch>()
 
-  function formatConnectorName() {
-    const { ethereum } = window
-    const isMetaMask = !!(ethereum && ethereum.isMetaMask)
-    const name = Object.keys(SUPPORTED_WALLETS)
-      .filter(
-        k =>
-          SUPPORTED_WALLETS[k].connector === connector && (connector !== injected || isMetaMask === (k === 'METAMASK'))
-      )
-      .map(k => SUPPORTED_WALLETS[k].name)[0]
-    return <WalletName>Connected with {name}</WalletName>
-  }
+//   function formatConnectorName() {
+//     const { ethereum } = window
+//     const isMetaMask = !!(ethereum && ethereum.isMetaMask)
+//     const name = Object.keys(SUPPORTED_WALLETS)
+//       .filter(
+//         k =>
+//           SUPPORTED_WALLETS[k].connector === connector && (connector !== injected || isMetaMask === (k === 'METAMASK'))
+//       )
+//       .map(k => SUPPORTED_WALLETS[k].name)[0]
+//     return <WalletName>Connected with {name}</WalletName>
+//   }
 
-  function getStatusIcon() {
-    if (connector === injected) {
-      return (
-        <IconWrapper size={16}>
-          <Identicon />
-        </IconWrapper>
-      )
-    } else if (connector === walletconnect) {
-      return (
-        <IconWrapper size={16}>
-          <img src={WalletConnectIcon} alt={'wallet connect logo'} />
-        </IconWrapper>
-      )
-    } else if (connector === walletlink) {
-      return (
-        <IconWrapper size={16}>
-          <img src={CoinbaseWalletIcon} alt={'coinbase wallet logo'} />
-        </IconWrapper>
-      )
-    } else if (connector === fortmatic) {
-      return (
-        <IconWrapper size={16}>
-          <img src={FortmaticIcon} alt={'fortmatic logo'} />
-        </IconWrapper>
-      )
-    } else if (connector === portis) {
-      return (
-        <>
-          <IconWrapper size={16}>
-            <img src={PortisIcon} alt={'portis logo'} />
-            <MainWalletAction
-              onClick={() => {
-                portis.portis.showPortis()
-              }}
-            >
-              Show Portis
-            </MainWalletAction>
-          </IconWrapper>
-        </>
-      )
-    }
-    return null
-  }
+//   function getStatusIcon() {
+//     if (connector === injected) {
+//       return (
+//         <IconWrapper size={16}>
+//           <Identicon />
+//         </IconWrapper>
+//       )
+//     } else if (connector === walletconnect) {
+//       return (
+//         <IconWrapper size={16}>
+//           <img src={WalletConnectIcon} alt={'wallet connect logo'} />
+//         </IconWrapper>
+//       )
+//     } else if (connector === walletlink) {
+//       return (
+//         <IconWrapper size={16}>
+//           <img src={CoinbaseWalletIcon} alt={'coinbase wallet logo'} />
+//         </IconWrapper>
+//       )
+//     } else if (connector === fortmatic) {
+//       return (
+//         <IconWrapper size={16}>
+//           <img src={FortmaticIcon} alt={'fortmatic logo'} />
+//         </IconWrapper>
+//       )
+//     } else if (connector === portis) {
+//       return (
+//         <>
+//           <IconWrapper size={16}>
+//             <img src={PortisIcon} alt={'portis logo'} />
+//             <MainWalletAction
+//               onClick={() => {
+//                 portis.portis.showPortis()
+//               }}
+//             >
+//               Show Portis
+//             </MainWalletAction>
+//           </IconWrapper>
+//         </>
+//       )
+//     }
+//     return null
+//   }
 
-  const clearAllTransactionsCallback = useCallback(() => {
-    if (chainId) {
-      batch(() => {
-        dispatch(clearAllTransactions({ chainId }))
-        dispatch(clearOrders({ chainId }))
-      })
-    }
-  }, [dispatch, chainId])
+//   const clearAllTransactionsCallback = useCallback(() => {
+//     if (chainId) {
+//       batch(() => {
+//         dispatch(clearAllTransactions({ chainId }))
+//         dispatch(clearOrders({ chainId }))
+//       })
+//     }
+//   }, [dispatch, chainId])
 
-  return (
-    <>
-      <UpperSection>
-        <CloseIcon onClick={toggleWalletModal}>
-          <CloseColor />
-        </CloseIcon>
-        <HeaderRow>Account</HeaderRow>
-        <AccountSection>
-          <YourAccount>
-            <InfoCard>
-              <AccountGroupingRow>
-                {formatConnectorName()}
-                <div>
-                  {connector !== injected && connector !== walletlink && (
-                    <WalletAction
-                      style={{ fontSize: '.825rem', fontWeight: 400, marginRight: '8px' }}
-                      onClick={() => {
-                        ;(connector as any).close()
-                      }}
-                    >
-                      Disconnect
-                    </WalletAction>
-                  )}
-                  <WalletAction
-                    style={{ fontSize: '.825rem', fontWeight: 400 }}
-                    onClick={() => {
-                      openOptions()
-                    }}
-                  >
-                    Change
-                  </WalletAction>
-                </div>
-              </AccountGroupingRow>
-              <AccountGroupingRow id="web3-account-identifier-row">
-                <AccountControl>
-                  {ENSName ? (
-                    <>
-                      <div>
-                        {getStatusIcon()}
-                        <p> {ENSName}</p>
-                      </div>
-                    </>
-                  ) : (
-                    <>
-                      <div>
-                        {getStatusIcon()}
-                        <p> {account && shortenAddress(account)}</p>
-                      </div>
-                    </>
-                  )}
-                </AccountControl>
-              </AccountGroupingRow>
-              <AccountGroupingRow>
-                {ENSName ? (
-                  <>
-                    <AccountControl>
-                      <div>
-                        {account && (
-                          <Copy toCopy={account}>
-                            <span style={{ marginLeft: '4px' }}>Copy Address</span>
-                          </Copy>
-                        )}
-                        {chainId && account && (
-                          <AddressLink
-                            hasENS={!!ENSName}
-                            isENS={true}
-                            href={chainId && getEtherscanLink(chainId, ENSName, 'address')}
-                          >
-                            <LinkIcon size={16} />
-                            <span style={{ marginLeft: '4px' }}>View on Etherscan</span>
-                          </AddressLink>
-                        )}
-                      </div>
-                    </AccountControl>
-                  </>
-                ) : (
-                  <>
-                    <AccountControl>
-                      <div>
-                        {account && (
-                          <Copy toCopy={account}>
-                            <span style={{ marginLeft: '4px' }}>Copy Address</span>
-                          </Copy>
-                        )}
-                        {chainId && account && (
-                          <AddressLink
-                            hasENS={!!ENSName}
-                            isENS={false}
-                            href={getEtherscanLink(chainId, account, 'address')}
-                          >
-                            <LinkIcon size={16} />
-                            <span style={{ marginLeft: '4px' }}>View on Etherscan</span>
-                          </AddressLink>
-                        )}
-                      </div>
-                    </AccountControl>
-                  </>
-                )}
-              </AccountGroupingRow>
-            </InfoCard>
-          </YourAccount>
-        </AccountSection>
-      </UpperSection>
-      {!!pendingTransactions.length || !!confirmedTransactions.length ? (
-        <LowerSection>
-          <AutoRow mb={'1rem'} style={{ justifyContent: 'space-between' }}>
-            <TYPE.body>Recent Transactions</TYPE.body>
-            <LinkStyledButton onClick={clearAllTransactionsCallback}>(clear all)</LinkStyledButton>
-          </AutoRow>
-          {renderTransactions(pendingTransactions)}
-          {renderTransactions(confirmedTransactions)}
-        </LowerSection>
-      ) : (
-        <LowerSection>
-          <TYPE.body color={theme.text1}>Your transactions will appear here...</TYPE.body>
-        </LowerSection>
-      )}
-    </>
-  )
-}
+//   return (
+//     <>
+//       <UpperSection>
+//         <CloseIcon onClick={toggleWalletModal}>
+//           <CloseColor />
+//         </CloseIcon>
+//         <HeaderRow>Account</HeaderRow>
+//         <AccountSection>
+//           <YourAccount>
+//             <InfoCard>
+//               <AccountGroupingRow>
+//                 {formatConnectorName()}
+//                 <div>
+//                   {connector !== injected && connector !== walletlink && (
+//                     <WalletAction
+//                       style={{ fontSize: '.825rem', fontWeight: 400, marginRight: '8px' }}
+//                       onClick={() => {
+//                         ;(connector as any).close()
+//                       }}
+//                     >
+//                       Disconnect
+//                     </WalletAction>
+//                   )}
+//                   <WalletAction
+//                     style={{ fontSize: '.825rem', fontWeight: 400 }}
+//                     onClick={() => {
+//                       openOptions()
+//                     }}
+//                   >
+//                     Change
+//                   </WalletAction>
+//                 </div>
+//               </AccountGroupingRow>
+//               <AccountGroupingRow id="web3-account-identifier-row">
+//                 <AccountControl>
+//                   {ENSName ? (
+//                     <>
+//                       <div>
+//                         {getStatusIcon()}
+//                         <p> {ENSName}</p>
+//                       </div>
+//                     </>
+//                   ) : (
+//                     <>
+//                       <div>
+//                         {getStatusIcon()}
+//                         <p> {account && shortenAddress(account)}</p>
+//                       </div>
+//                     </>
+//                   )}
+//                 </AccountControl>
+//               </AccountGroupingRow>
+//               <AccountGroupingRow>
+//                 {ENSName ? (
+//                   <>
+//                     <AccountControl>
+//                       <div>
+//                         {account && (
+//                           <Copy toCopy={account}>
+//                             <span style={{ marginLeft: '4px' }}>Copy Address</span>
+//                           </Copy>
+//                         )}
+//                         {chainId && account && (
+//                           <AddressLink
+//                             hasENS={!!ENSName}
+//                             isENS={true}
+//                             href={chainId && getEtherscanLink(chainId, ENSName, 'address')}
+//                           >
+//                             <LinkIcon size={16} />
+//                             <span style={{ marginLeft: '4px' }}>View on Etherscan</span>
+//                           </AddressLink>
+//                         )}
+//                       </div>
+//                     </AccountControl>
+//                   </>
+//                 ) : (
+//                   <>
+//                     <AccountControl>
+//                       <div>
+//                         {account && (
+//                           <Copy toCopy={account}>
+//                             <span style={{ marginLeft: '4px' }}>Copy Address</span>
+//                           </Copy>
+//                         )}
+//                         {chainId && account && (
+//                           <AddressLink
+//                             hasENS={!!ENSName}
+//                             isENS={false}
+//                             href={getEtherscanLink(chainId, account, 'address')}
+//                           >
+//                             <LinkIcon size={16} />
+//                             <span style={{ marginLeft: '4px' }}>View on Etherscan</span>
+//                           </AddressLink>
+//                         )}
+//                       </div>
+//                     </AccountControl>
+//                   </>
+//                 )}
+//               </AccountGroupingRow>
+//             </InfoCard>
+//           </YourAccount>
+//         </AccountSection>
+//       </UpperSection>
+//       {!!pendingTransactions.length || !!confirmedTransactions.length ? (
+//         <LowerSection>
+//           <AutoRow mb={'1rem'} style={{ justifyContent: 'space-between' }}>
+//             <TYPE.body>Recent Transactions</TYPE.body>
+//             <LinkStyledButton onClick={clearAllTransactionsCallback}>(clear all)</LinkStyledButton>
+//           </AutoRow>
+//           {renderTransactions(pendingTransactions)}
+//           {renderTransactions(confirmedTransactions)}
+//         </LowerSection>
+//       ) : (
+//         <LowerSection>
+//           <TYPE.body color={theme.text1}>Your transactions will appear here...</TYPE.body>
+//         </LowerSection>
+//       )}
+//     </>
+//   )
+// }

--- a/src/custom/components/AccountDetails/AccountDetailsMod.tsx
+++ b/src/custom/components/AccountDetails/AccountDetailsMod.tsx
@@ -1,0 +1,417 @@
+import React, { useCallback, useContext } from 'react'
+import { batch, useDispatch } from 'react-redux'
+import styled, { ThemeContext } from 'styled-components'
+import { useActiveWeb3React } from 'hooks'
+import { AppDispatch } from 'state'
+import { clearAllTransactions } from 'state/transactions/actions'
+import { shortenAddress } from 'utils'
+import { AutoRow } from 'components/Row'
+import Copy from 'components/AccountDetails/Copy'
+import Transaction from 'components/AccountDetails/Transaction'
+
+import { SUPPORTED_WALLETS } from 'constants/index'
+import { ReactComponent as Close } from 'assets/images/x.svg'
+import { getEtherscanLink } from 'utils'
+import { injected, walletconnect, walletlink, fortmatic, portis } from 'connectors'
+import CoinbaseWalletIcon from 'assets/images/coinbaseWalletIcon.svg'
+import WalletConnectIcon from 'assets/images/walletConnectIcon.svg'
+import FortmaticIcon from 'assets/images/fortmaticIcon.png'
+import PortisIcon from 'assets/images/portisIcon.png'
+import Identicon from 'components/Identicon'
+import { ButtonSecondary } from '../Button'
+import { ExternalLink as LinkIcon } from 'react-feather'
+import { ExternalLink, LinkStyledButton, TYPE } from 'theme'
+import { clearOrders } from 'state/orders/actions'
+
+export const HeaderRow = styled.div`
+  ${({ theme }) => theme.flexRowNoWrap};
+  padding: 1rem 1rem;
+  font-weight: 500;
+  color: ${props => (props.color === 'blue' ? ({ theme }) => theme.primary1 : 'inherit')};
+  ${({ theme }) => theme.mediaWidth.upToMedium`
+    padding: 1rem;
+  `};
+`
+
+export const UpperSection = styled.div`
+  position: relative;
+
+  h5 {
+    margin: 0;
+    margin-bottom: 0.5rem;
+    font-size: 1rem;
+    font-weight: 400;
+  }
+
+  h5:last-child {
+    margin-bottom: 0px;
+  }
+
+  h4 {
+    margin-top: 0;
+    font-weight: 500;
+  }
+`
+
+export const InfoCard = styled.div`
+  padding: 1rem;
+  border: 1px solid ${({ theme }) => theme.bg3};
+  border-radius: 20px;
+  position: relative;
+  display: grid;
+  grid-row-gap: 12px;
+  margin-bottom: 20px;
+`
+
+export const AccountGroupingRow = styled.div`
+  ${({ theme }) => theme.flexRowNoWrap};
+  justify-content: space-between;
+  align-items: center;
+  font-weight: 400;
+  color: ${({ theme }) => theme.text1};
+
+  div {
+    ${({ theme }) => theme.flexRowNoWrap}
+    align-items: center;
+  }
+`
+
+export const AccountSection = styled.div`
+  background-color: ${({ theme }) => theme.bg1};
+  padding: 0rem 1rem;
+  ${({ theme }) => theme.mediaWidth.upToMedium`padding: 0rem 1rem 1.5rem 1rem;`};
+`
+
+export const YourAccount = styled.div`
+  h5 {
+    margin: 0 0 1rem 0;
+    font-weight: 400;
+  }
+
+  h4 {
+    margin: 0;
+    font-weight: 500;
+  }
+`
+
+export const LowerSection = styled.div`
+  ${({ theme }) => theme.flexColumnNoWrap}
+  padding: 1.5rem;
+  flex-grow: 1;
+  overflow: auto;
+  background-color: ${({ theme }) => theme.bg2};
+  border-bottom-left-radius: 20px;
+  border-bottom-right-radius: 20px;
+
+  h5 {
+    margin: 0;
+    font-weight: 400;
+    color: ${({ theme }) => theme.text3};
+  }
+`
+
+export const AccountControl = styled.div`
+  display: flex;
+  justify-content: space-between;
+  min-width: 0;
+  width: 100%;
+
+  font-weight: 500;
+  font-size: 1.25rem;
+
+  a:hover {
+    text-decoration: underline;
+  }
+
+  p {
+    min-width: 0;
+    margin: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+`
+
+export const AddressLink = styled(ExternalLink)<{ hasENS: boolean; isENS: boolean }>`
+  font-size: 0.825rem;
+  color: ${({ theme }) => theme.text3};
+  margin-left: 1rem;
+  font-size: 0.825rem;
+  display: flex;
+  :hover {
+    color: ${({ theme }) => theme.text2};
+  }
+`
+
+export const CloseIcon = styled.div`
+  position: absolute;
+  right: 1rem;
+  top: 14px;
+  &:hover {
+    cursor: pointer;
+    opacity: 0.6;
+  }
+`
+
+export const CloseColor = styled(Close)`
+  path {
+    stroke: ${({ theme }) => theme.text4};
+  }
+`
+
+export const WalletName = styled.div`
+  width: initial;
+  font-size: 0.825rem;
+  font-weight: 500;
+  color: ${({ theme }) => theme.text3};
+`
+
+export const IconWrapper = styled.div<{ size?: number }>`
+  ${({ theme }) => theme.flexColumnNoWrap};
+  align-items: center;
+  justify-content: center;
+  margin-right: 8px;
+  & > img,
+  span {
+    height: ${({ size }) => (size ? size + 'px' : '32px')};
+    width: ${({ size }) => (size ? size + 'px' : '32px')};
+  }
+  ${({ theme }) => theme.mediaWidth.upToMedium`
+    align-items: flex-end;
+  `};
+`
+
+export const TransactionListWrapper = styled.div`
+  ${({ theme }) => theme.flexColumnNoWrap};
+`
+
+export const WalletAction = styled(ButtonSecondary)`
+  width: fit-content;
+  font-weight: 400;
+  margin-left: 8px;
+  font-size: 0.825rem;
+  padding: 4px 6px;
+  :hover {
+    cursor: pointer;
+    text-decoration: underline;
+  }
+`
+
+export const MainWalletAction = styled(WalletAction)`
+  color: ${({ theme }) => theme.primary1};
+`
+
+export function renderTransactions(transactions: string[]) {
+  return (
+    <TransactionListWrapper>
+      {transactions.map((hash, i) => {
+        return <Transaction key={i} hash={hash} />
+      })}
+    </TransactionListWrapper>
+  )
+}
+
+export interface AccountDetailsProps {
+  toggleWalletModal: () => void
+  pendingTransactions: string[]
+  confirmedTransactions: string[]
+  ENSName?: string
+  openOptions: () => void
+}
+
+export default function AccountDetails({
+  toggleWalletModal,
+  pendingTransactions,
+  confirmedTransactions,
+  ENSName,
+  openOptions
+}: AccountDetailsProps) {
+  const { chainId, account, connector } = useActiveWeb3React()
+  const theme = useContext(ThemeContext)
+  const dispatch = useDispatch<AppDispatch>()
+
+  function formatConnectorName() {
+    const { ethereum } = window
+    const isMetaMask = !!(ethereum && ethereum.isMetaMask)
+    const name = Object.keys(SUPPORTED_WALLETS)
+      .filter(
+        k =>
+          SUPPORTED_WALLETS[k].connector === connector && (connector !== injected || isMetaMask === (k === 'METAMASK'))
+      )
+      .map(k => SUPPORTED_WALLETS[k].name)[0]
+    return <WalletName>Connected with {name}</WalletName>
+  }
+
+  function getStatusIcon() {
+    if (connector === injected) {
+      return (
+        <IconWrapper size={16}>
+          <Identicon />
+        </IconWrapper>
+      )
+    } else if (connector === walletconnect) {
+      return (
+        <IconWrapper size={16}>
+          <img src={WalletConnectIcon} alt={'wallet connect logo'} />
+        </IconWrapper>
+      )
+    } else if (connector === walletlink) {
+      return (
+        <IconWrapper size={16}>
+          <img src={CoinbaseWalletIcon} alt={'coinbase wallet logo'} />
+        </IconWrapper>
+      )
+    } else if (connector === fortmatic) {
+      return (
+        <IconWrapper size={16}>
+          <img src={FortmaticIcon} alt={'fortmatic logo'} />
+        </IconWrapper>
+      )
+    } else if (connector === portis) {
+      return (
+        <>
+          <IconWrapper size={16}>
+            <img src={PortisIcon} alt={'portis logo'} />
+            <MainWalletAction
+              onClick={() => {
+                portis.portis.showPortis()
+              }}
+            >
+              Show Portis
+            </MainWalletAction>
+          </IconWrapper>
+        </>
+      )
+    }
+    return null
+  }
+
+  const clearAllTransactionsCallback = useCallback(() => {
+    if (chainId) {
+      batch(() => {
+        dispatch(clearAllTransactions({ chainId }))
+        dispatch(clearOrders({ chainId }))
+      })
+    }
+  }, [dispatch, chainId])
+
+  return (
+    <>
+      <UpperSection>
+        <CloseIcon onClick={toggleWalletModal}>
+          <CloseColor />
+        </CloseIcon>
+        <HeaderRow>Account</HeaderRow>
+        <AccountSection>
+          <YourAccount>
+            <InfoCard>
+              <AccountGroupingRow>
+                {formatConnectorName()}
+                <div>
+                  {connector !== injected && connector !== walletlink && (
+                    <WalletAction
+                      style={{ fontSize: '.825rem', fontWeight: 400, marginRight: '8px' }}
+                      onClick={() => {
+                        ;(connector as any).close()
+                      }}
+                    >
+                      Disconnect
+                    </WalletAction>
+                  )}
+                  <WalletAction
+                    style={{ fontSize: '.825rem', fontWeight: 400 }}
+                    onClick={() => {
+                      openOptions()
+                    }}
+                  >
+                    Change
+                  </WalletAction>
+                </div>
+              </AccountGroupingRow>
+              <AccountGroupingRow id="web3-account-identifier-row">
+                <AccountControl>
+                  {ENSName ? (
+                    <>
+                      <div>
+                        {getStatusIcon()}
+                        <p> {ENSName}</p>
+                      </div>
+                    </>
+                  ) : (
+                    <>
+                      <div>
+                        {getStatusIcon()}
+                        <p> {account && shortenAddress(account)}</p>
+                      </div>
+                    </>
+                  )}
+                </AccountControl>
+              </AccountGroupingRow>
+              <AccountGroupingRow>
+                {ENSName ? (
+                  <>
+                    <AccountControl>
+                      <div>
+                        {account && (
+                          <Copy toCopy={account}>
+                            <span style={{ marginLeft: '4px' }}>Copy Address</span>
+                          </Copy>
+                        )}
+                        {chainId && account && (
+                          <AddressLink
+                            hasENS={!!ENSName}
+                            isENS={true}
+                            href={chainId && getEtherscanLink(chainId, ENSName, 'address')}
+                          >
+                            <LinkIcon size={16} />
+                            <span style={{ marginLeft: '4px' }}>View on Etherscan</span>
+                          </AddressLink>
+                        )}
+                      </div>
+                    </AccountControl>
+                  </>
+                ) : (
+                  <>
+                    <AccountControl>
+                      <div>
+                        {account && (
+                          <Copy toCopy={account}>
+                            <span style={{ marginLeft: '4px' }}>Copy Address</span>
+                          </Copy>
+                        )}
+                        {chainId && account && (
+                          <AddressLink
+                            hasENS={!!ENSName}
+                            isENS={false}
+                            href={getEtherscanLink(chainId, account, 'address')}
+                          >
+                            <LinkIcon size={16} />
+                            <span style={{ marginLeft: '4px' }}>View on Etherscan</span>
+                          </AddressLink>
+                        )}
+                      </div>
+                    </AccountControl>
+                  </>
+                )}
+              </AccountGroupingRow>
+            </InfoCard>
+          </YourAccount>
+        </AccountSection>
+      </UpperSection>
+      {!!pendingTransactions.length || !!confirmedTransactions.length ? (
+        <LowerSection>
+          <AutoRow mb={'1rem'} style={{ justifyContent: 'space-between' }}>
+            <TYPE.body>Recent Transactions</TYPE.body>
+            <LinkStyledButton onClick={clearAllTransactionsCallback}>(clear all)</LinkStyledButton>
+          </AutoRow>
+          {renderTransactions(pendingTransactions)}
+          {renderTransactions(confirmedTransactions)}
+        </LowerSection>
+      ) : (
+        <LowerSection>
+          <TYPE.body color={theme.text1}>Your transactions will appear here...</TYPE.body>
+        </LowerSection>
+      )}
+    </>
+  )
+}

--- a/src/custom/components/AccountDetails/index.tsx
+++ b/src/custom/components/AccountDetails/index.tsx
@@ -17,13 +17,14 @@ import FortmaticIcon from 'assets/images/fortmaticIcon.png'
 import PortisIcon from 'assets/images/portisIcon.png'
 import Identicon from 'components/Identicon'
 import { ExternalLink as LinkIcon } from 'react-feather'
-import { CloseIcon, LinkStyledButton, TYPE } from 'theme'
+import { LinkStyledButton, TYPE } from 'theme'
 import { clearOrders } from 'state/orders/actions'
 import {
   WalletName,
   MainWalletAction,
   AccountDetailsProps,
   UpperSection,
+  CloseIcon,
   CloseColor,
   HeaderRow,
   AccountSection,

--- a/src/custom/components/AccountDetails/index.tsx
+++ b/src/custom/components/AccountDetails/index.tsx
@@ -1,0 +1,237 @@
+import React, { useCallback, useContext } from 'react'
+import { batch, useDispatch } from 'react-redux'
+import { ThemeContext } from 'styled-components'
+import { useActiveWeb3React } from 'hooks'
+import { AppDispatch } from 'state'
+import { clearAllTransactions } from 'state/transactions/actions'
+import { shortenAddress } from 'utils'
+import { AutoRow } from 'components/Row'
+import Copy from 'components/AccountDetails/Copy'
+
+import { SUPPORTED_WALLETS } from 'constants/index'
+import { getEtherscanLink } from 'utils'
+import { injected, walletconnect, walletlink, fortmatic, portis } from 'connectors'
+import CoinbaseWalletIcon from 'assets/images/coinbaseWalletIcon.svg'
+import WalletConnectIcon from 'assets/images/walletConnectIcon.svg'
+import FortmaticIcon from 'assets/images/fortmaticIcon.png'
+import PortisIcon from 'assets/images/portisIcon.png'
+import Identicon from 'components/Identicon'
+import { ExternalLink as LinkIcon } from 'react-feather'
+import { CloseIcon, LinkStyledButton, TYPE } from 'theme'
+import { clearOrders } from 'state/orders/actions'
+import {
+  WalletName,
+  MainWalletAction,
+  AccountDetailsProps,
+  UpperSection,
+  CloseColor,
+  HeaderRow,
+  AccountSection,
+  YourAccount,
+  InfoCard,
+  AccountGroupingRow,
+  WalletAction,
+  AccountControl,
+  AddressLink,
+  LowerSection,
+  IconWrapper,
+  renderTransactions
+} from './AccountDetailsMod'
+
+type AbstractConnector = Pick<ReturnType<typeof useActiveWeb3React>, 'connector'>['connector']
+
+export function formatConnectorName(connector?: AbstractConnector) {
+  const { ethereum } = window
+  const isMetaMask = !!(ethereum && ethereum.isMetaMask)
+  const name = Object.keys(SUPPORTED_WALLETS)
+    .filter(
+      k => SUPPORTED_WALLETS[k].connector === connector && (connector !== injected || isMetaMask === (k === 'METAMASK'))
+    )
+    .map(k => SUPPORTED_WALLETS[k].name)[0]
+  return <WalletName>Connected with {name}</WalletName>
+}
+
+export function getStatusIcon(connector?: AbstractConnector) {
+  if (connector === injected) {
+    return (
+      <IconWrapper size={16}>
+        <Identicon />
+      </IconWrapper>
+    )
+  } else if (connector === walletconnect) {
+    return (
+      <IconWrapper size={16}>
+        <img src={WalletConnectIcon} alt={'wallet connect logo'} />
+      </IconWrapper>
+    )
+  } else if (connector === walletlink) {
+    return (
+      <IconWrapper size={16}>
+        <img src={CoinbaseWalletIcon} alt={'coinbase wallet logo'} />
+      </IconWrapper>
+    )
+  } else if (connector === fortmatic) {
+    return (
+      <IconWrapper size={16}>
+        <img src={FortmaticIcon} alt={'fortmatic logo'} />
+      </IconWrapper>
+    )
+  } else if (connector === portis) {
+    return (
+      <>
+        <IconWrapper size={16}>
+          <img src={PortisIcon} alt={'portis logo'} />
+          <MainWalletAction
+            onClick={() => {
+              portis.portis.showPortis()
+            }}
+          >
+            Show Portis
+          </MainWalletAction>
+        </IconWrapper>
+      </>
+    )
+  }
+  return null
+}
+
+export default function AccountDetails({
+  toggleWalletModal,
+  pendingTransactions,
+  confirmedTransactions,
+  ENSName,
+  openOptions
+}: AccountDetailsProps) {
+  const { chainId, account, connector } = useActiveWeb3React()
+  const theme = useContext(ThemeContext)
+  const dispatch = useDispatch<AppDispatch>()
+
+  const clearAllActivityCallback = useCallback(() => {
+    if (chainId) {
+      batch(() => {
+        dispatch(clearAllTransactions({ chainId }))
+        dispatch(clearOrders({ chainId }))
+      })
+    }
+  }, [dispatch, chainId])
+
+  return (
+    <>
+      <UpperSection>
+        <CloseIcon onClick={toggleWalletModal}>
+          <CloseColor />
+        </CloseIcon>
+        <HeaderRow>Account</HeaderRow>
+        <AccountSection>
+          <YourAccount>
+            <InfoCard>
+              <AccountGroupingRow>
+                {formatConnectorName()}
+                <div>
+                  {connector !== injected && connector !== walletlink && (
+                    <WalletAction
+                      style={{ fontSize: '.825rem', fontWeight: 400, marginRight: '8px' }}
+                      onClick={() => {
+                        ;(connector as any).close()
+                      }}
+                    >
+                      Disconnect
+                    </WalletAction>
+                  )}
+                  <WalletAction
+                    style={{ fontSize: '.825rem', fontWeight: 400 }}
+                    onClick={() => {
+                      openOptions()
+                    }}
+                  >
+                    Change
+                  </WalletAction>
+                </div>
+              </AccountGroupingRow>
+              <AccountGroupingRow id="web3-account-identifier-row">
+                <AccountControl>
+                  {ENSName ? (
+                    <>
+                      <div>
+                        {getStatusIcon()}
+                        <p> {ENSName}</p>
+                      </div>
+                    </>
+                  ) : (
+                    <>
+                      <div>
+                        {getStatusIcon()}
+                        <p> {account && shortenAddress(account)}</p>
+                      </div>
+                    </>
+                  )}
+                </AccountControl>
+              </AccountGroupingRow>
+              <AccountGroupingRow>
+                {ENSName ? (
+                  <>
+                    <AccountControl>
+                      <div>
+                        {account && (
+                          <Copy toCopy={account}>
+                            <span style={{ marginLeft: '4px' }}>Copy Address</span>
+                          </Copy>
+                        )}
+                        {chainId && account && (
+                          <AddressLink
+                            hasENS={!!ENSName}
+                            isENS={true}
+                            href={chainId && getEtherscanLink(chainId, ENSName, 'address')}
+                          >
+                            <LinkIcon size={16} />
+                            <span style={{ marginLeft: '4px' }}>View on Etherscan</span>
+                          </AddressLink>
+                        )}
+                      </div>
+                    </AccountControl>
+                  </>
+                ) : (
+                  <>
+                    <AccountControl>
+                      <div>
+                        {account && (
+                          <Copy toCopy={account}>
+                            <span style={{ marginLeft: '4px' }}>Copy Address</span>
+                          </Copy>
+                        )}
+                        {chainId && account && (
+                          <AddressLink
+                            hasENS={!!ENSName}
+                            isENS={false}
+                            href={getEtherscanLink(chainId, account, 'address')}
+                          >
+                            <LinkIcon size={16} />
+                            <span style={{ marginLeft: '4px' }}>View on Etherscan</span>
+                          </AddressLink>
+                        )}
+                      </div>
+                    </AccountControl>
+                  </>
+                )}
+              </AccountGroupingRow>
+            </InfoCard>
+          </YourAccount>
+        </AccountSection>
+      </UpperSection>
+      {!!pendingTransactions.length || !!confirmedTransactions.length ? (
+        <LowerSection>
+          <AutoRow mb={'1rem'} style={{ justifyContent: 'space-between' }}>
+            <TYPE.body>Recent Activity</TYPE.body>
+            <LinkStyledButton onClick={clearAllActivityCallback}>(clear all)</LinkStyledButton>
+          </AutoRow>
+          {renderTransactions(pendingTransactions)}
+          {renderTransactions(confirmedTransactions)}
+        </LowerSection>
+      ) : (
+        <LowerSection>
+          <TYPE.body color={theme.text1}>Your activity will appear here...</TYPE.body>
+        </LowerSection>
+      )}
+    </>
+  )
+}


### PR DESCRIPTION
### Clear All button in Transactions list was only removing transactions from state, not orders as well

## AccountDetailsMod & custom/components/AccountDetails`
1. ovewrites AccountDetails.tsx, moves the internal functions out of comp and exports them:
  a. `formatConnectorName`
  b. `getStatusIcon` 
2. Inside `custom/AccountDetails/index` > line `222`
  a. Recent Transactions = Recent Activity

To test: 
1. open console and run `addNOrders(10)`
2. swap something normally
3. when you have pending TX and Pending Orders or Confirmed orders or expired orders (need orders and tx to test properly)
4. hit "clear all"
5. should delete all the things

Wasn't doing that before

ALSO

### Minor Changes (cosmetic)
1. rename `Recent Transactions` > `Recent Activity`
2. when no activity: WAS: `Your transactions will appear here...` and is NOW: `Your activity will appear here...`