### PR TITLE
[FIX] Pending TX showing as confirmed

### DIFF
--- a/src/custom/hooks/useRecentActivity.ts
+++ b/src/custom/hooks/useRecentActivity.ts
@@ -127,7 +127,7 @@ export function useActivityDescriptors({ chainId, id }: { chainId?: number; id: 
       // setup variables accordingly...
       const isReceiptConfirmed =
         tx.receipt?.status === TxReceiptStatus.CONFIRMED || typeof tx.receipt?.status === 'undefined'
-      isPending = !!tx?.receipt
+      isPending = !tx?.receipt
       isConfirmed = !isPending && isReceiptConfirmed
 
       activity = tx


### PR DESCRIPTION
As title states

When approving a token for example, was showing immediately confirmed and still pending in the counter. Due to a boolean check issue.