### PR TITLE
Fix trade event watching

### DIFF
--- a/src/custom/state/orders/updater.ts
+++ b/src/custom/state/orders/updater.ts
@@ -12,7 +12,7 @@ import { registerOnWindow } from 'utils/misc'
 import { GP_SETTLEMENT_CONTRACT_ADDRESS } from 'constants/index'
 import { GP_V2_SETTLEMENT_INTERFACE } from '@src/custom/constants/GPv2Settlement'
 
-type OrderLogPupupMixData = OrderFulfillmentData & Pick<Log, 'transactionHash'> & Partial<Pick<Order, 'summary'>>
+type OrderLogPopupMixData = OrderFulfillmentData & Pick<Log, 'transactionHash'> & Partial<Pick<Order, 'summary'>>
 
 const TradeEvent = GP_V2_SETTLEMENT_INTERFACE.getEvent('Trade')
 
@@ -147,7 +147,7 @@ export function EventUpdater(): null {
 
       const block2DateMap = await buildBlock2DateMap(library, logs)
 
-      const ordersBatchData: OrderLogPupupMixData[] = logs.map(log => {
+      const ordersBatchData: OrderLogPopupMixData[] = logs.map(log => {
         const { orderUid: id } = decodeTradeEvent(log)
 
         console.log(`EventUpdater::Detected Trade event for order ${id} of token in block`, log.blockNumber)

--- a/src/custom/state/orders/updater.ts
+++ b/src/custom/state/orders/updater.ts
@@ -181,7 +181,7 @@ export function EventUpdater(): null {
                   summary: summary || `Order ${id} was traded`
                 }
               },
-              transactionHash
+              id
             )
           } catch (error) {
             console.error('Error decoding Trade event', error)

--- a/src/custom/state/orders/updater.ts
+++ b/src/custom/state/orders/updater.ts
@@ -122,7 +122,7 @@ export function EventUpdater(): null {
         return getLogsRetry({
           fromBlock,
           toBlock,
-          topics: TransferEventTopics
+          topics: eventTopics
         })
       }
     })

--- a/src/custom/state/orders/updater.ts
+++ b/src/custom/state/orders/updater.ts
@@ -3,8 +3,7 @@ import { useDispatch, batch } from 'react-redux'
 import { useActiveWeb3React } from 'hooks'
 import { useAddPopup, useBlockNumber } from 'state/application/hooks'
 import { AppDispatch } from 'state'
-import { OrderFulfillmentData } from './actions'
-import { utils } from 'ethers'
+import { OrderFulfillmentData, Order } from './actions'
 import { Web3Provider } from '@ethersproject/providers'
 import { Log, Filter } from '@ethersproject/abstract-provider'
 import { useLastCheckedBlock, usePendingOrders, useExpireOrder, useFulfillOrdersBatch } from './hooks'
@@ -13,9 +12,7 @@ import { registerOnWindow } from 'utils/misc'
 import { GP_SETTLEMENT_CONTRACT_ADDRESS } from 'constants/index'
 import { GP_V2_SETTLEMENT_INTERFACE } from '@src/custom/constants/GPv2Settlement'
 
-// example of event watching + decoding without contract
-const transferEventAbi = 'event Transfer(address indexed from, address indexed to, uint amount)'
-const ERC20Interface = new utils.Interface([transferEventAbi])
+type OrderLogPupupMixData = OrderFulfillmentData & Pick<Log, 'transactionHash'> & Partial<Pick<Order, 'summary'>>
 
 const TradeEvent = GP_V2_SETTLEMENT_INTERFACE.getEvent('Trade')
 

--- a/src/custom/state/orders/updater.ts
+++ b/src/custom/state/orders/updater.ts
@@ -10,7 +10,7 @@ import { Log, Filter } from '@ethersproject/abstract-provider'
 import { useLastCheckedBlock, usePendingOrders, useExpireOrder, useFulfillOrdersBatch } from './hooks'
 import { buildBlock2DateMap } from 'utils/blocks'
 import { registerOnWindow } from 'utils/misc'
-// import { PartialOrdersMap } from './reducer'
+import { GP_SETTLEMENT_CONTRACT_ADDRESS } from 'constants/index'
 
 // example of event watching + decoding without contract
 const transferEventAbi = 'event Transfer(address indexed from, address indexed to, uint amount)'
@@ -123,6 +123,7 @@ export function EventUpdater(): null {
     return generateTradeEventTopics({ owner: account })
   }, [account])
 
+  const contractAddress = chainId && GP_SETTLEMENT_CONTRACT_ADDRESS[chainId]
   useEffect(() => {
     if (!chainId || !library || !getLogsRetry || !lastBlockNumber || !eventTopics) return
 
@@ -228,7 +229,7 @@ export function EventUpdater(): null {
     dispatch,
     addPopup,
     eventTopics,
-    fulfillOrdersBatch
+    contractAddress,
   ])
 
   // TODO: maybe implement event watching instead of getPastEvents on every block


### PR DESCRIPTION
- Events had an incorrect topic, switched to using Interface constructed from ABI directly
- Adds filling in of Order.summary for the popup (when Order is in store). TODO: move to Popup middleware
- Fixes non-unique popup.key
![localhost_3000_](https://user-images.githubusercontent.com/5121491/102496887-0bf16a00-4089-11eb-8278-0d35dfeb2681.png)

How to test:
0. Start [here](https://pr82--gpv2swap.review.gnosisdev.com/#/swap?inputCurrency=0xc778417E063141139Fce010982780140Aa0cD5Ab&outputCurrency=0x5592EC0cfb4dbc12D3aB100b257153436a1f0FEa)
1. on Rinkeby
2. Sell 0.1 WETH for whatever DAI
3. Sell 90 DAI for WETH
4. Wait

steps courtesy of @fleupold