### PR TITLE
Add Versions to bottom left of app

### DIFF
--- a/src/custom/components/Version/index.tsx
+++ b/src/custom/components/Version/index.tsx
@@ -5,51 +5,71 @@ import { ExternalLink, TYPE } from 'theme'
 import { GP_SETTLEMENT_CONTRACT_ADDRESS } from 'custom/constants'
 import { getEtherscanLink } from 'utils'
 
+import { version as WEB, dependencies } from 'src/../../package.json'
+
+const VERSIONS = {
+  WEB,
+  CONTRACTS: dependencies['@gnosis.pm/gp-v2-contracts']
+}
+
+const versionsMap = new Map(Object.entries(VERSIONS))
+const versionsList = Array.from(versionsMap)
+
 const StyledPolling = styled.div`
   position: fixed;
   display: flex;
   flex-flow: column nowrap;
   align-items: flex-start;
+
   left: 0;
   bottom: 0;
+
   padding: 1rem;
-  color: white;
-  transition: opacity 0.25s ease;
+
   color: ${({ theme }) => theme.green1};
-  :hover {
+  opacity: 0.4;
+
+  &:hover {
     opacity: 1;
   }
+
+  transition: opacity 0.25s ease;
 
   ${({ theme }) => theme.mediaWidth.upToMedium`
     display: none;
   `}
 `
 
-type VERSIONS_MAP = Record<'WEB' | 'CONTRACTS', string>
+const VersionsExternalLink = styled(ExternalLink)<{ isUnclickable?: boolean }>`
+  ${({ isUnclickable = false }): string | false =>
+    isUnclickable &&
+    `
+      pointer-events: none;
+      curose: none;
+  `}
+`
 
-const VERSIONS: VERSIONS_MAP = {
-  WEB: '0.2.0-DEMO',
-  CONTRACTS: '0.1.0-alpha10'
-}
-
-const VersionMap = new Map(Object.entries(VERSIONS))
-const VersionList = Array.from(VersionMap)
+const VersionData = ({ versions }: { versions: [string, string][] }) => (
+  <StyledPolling>
+    {versions.map(([key, val]) => (
+      <TYPE.small key={key}>
+        {key}: <strong>{val}</strong>
+      </TYPE.small>
+    ))}
+  </StyledPolling>
+)
 
 const Version = () => {
   const { chainId } = useActiveWeb3React()
-
   const swapAddress = chainId ? GP_SETTLEMENT_CONTRACT_ADDRESS[chainId] : null
 
   return (
-    <ExternalLink href={chainId && swapAddress ? getEtherscanLink(chainId, swapAddress, 'address') : ''}>
-      <StyledPolling>
-        {VersionList.map(([key, val]) => (
-          <TYPE.small key={key}>
-            {key}: {val}
-          </TYPE.small>
-        ))}
-      </StyledPolling>
-    </ExternalLink>
+    <VersionsExternalLink
+      isUnclickable={!chainId || !swapAddress}
+      href={chainId && swapAddress ? getEtherscanLink(chainId, swapAddress, 'address') : ''}
+    >
+      <VersionData versions={versionsList} />
+    </VersionsExternalLink>
   )
 }
 

--- a/src/custom/components/Version/index.tsx
+++ b/src/custom/components/Version/index.tsx
@@ -5,11 +5,12 @@ import { ExternalLink, TYPE } from 'theme'
 import { GP_SETTLEMENT_CONTRACT_ADDRESS } from 'custom/constants'
 import { getEtherscanLink } from 'utils'
 
-import { version as WEB, dependencies } from 'src/../../package.json'
+import { version as WEB } from 'src/../../package.json'
+import { version as CONTRACTS } from '@gnosis.pm/gp-v2-contracts/package.json'
 
 const VERSIONS = {
   WEB,
-  CONTRACTS: dependencies['@gnosis.pm/gp-v2-contracts']
+  CONTRACTS
 }
 
 const versionsList = Object.entries(VERSIONS)
@@ -48,7 +49,7 @@ const VersionsExternalLink = styled(ExternalLink)<{ isUnclickable?: boolean }>`
   `}
 `
 
-const VersionData = ({ versions }: { versions: [string, string][] }) => (
+const VersionData = ({ versions }: { versions: typeof versionsList }) => (
   <StyledPolling>
     {versions.map(([key, val]) => (
       <TYPE.small key={key}>

--- a/src/custom/components/Version/index.tsx
+++ b/src/custom/components/Version/index.tsx
@@ -5,7 +5,7 @@ import { ExternalLink, TYPE } from 'theme'
 import { GP_SETTLEMENT_CONTRACT_ADDRESS } from 'custom/constants'
 import { getEtherscanLink } from 'utils'
 
-import { version as WEB } from 'src/../../package.json'
+import { version as WEB } from '@src/../package.json'
 import { version as CONTRACTS } from '@gnosis.pm/gp-v2-contracts/package.json'
 
 const VERSIONS = {

--- a/src/custom/components/Version/index.tsx
+++ b/src/custom/components/Version/index.tsx
@@ -12,8 +12,7 @@ const VERSIONS = {
   CONTRACTS: dependencies['@gnosis.pm/gp-v2-contracts']
 }
 
-const versionsMap = new Map(Object.entries(VERSIONS))
-const versionsList = Array.from(versionsMap)
+const versionsList = Object.entries(VERSIONS)
 
 const StyledPolling = styled.div`
   position: fixed;

--- a/src/custom/components/Version/index.tsx
+++ b/src/custom/components/Version/index.tsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import styled from 'styled-components'
+import { useActiveWeb3React } from 'hooks'
+import { ExternalLink, TYPE } from 'theme'
+import { GP_SETTLEMENT_CONTRACT_ADDRESS } from 'custom/constants'
+import { getEtherscanLink } from 'utils'
+
+const StyledPolling = styled.div`
+  position: fixed;
+  display: flex;
+  flex-flow: column nowrap;
+  align-items: flex-start;
+  left: 0;
+  bottom: 0;
+  padding: 1rem;
+  color: white;
+  transition: opacity 0.25s ease;
+  color: ${({ theme }) => theme.green1};
+  :hover {
+    opacity: 1;
+  }
+
+  ${({ theme }) => theme.mediaWidth.upToMedium`
+    display: none;
+  `}
+`
+
+type VERSIONS_MAP = Record<'WEB' | 'CONTRACTS', string>
+
+const VERSIONS: VERSIONS_MAP = {
+  WEB: '0.2.0-DEMO',
+  CONTRACTS: '0.1.0-alpha10'
+}
+
+const VersionMap = new Map(Object.entries(VERSIONS))
+const VersionList = Array.from(VersionMap)
+
+const Version = () => {
+  const { chainId } = useActiveWeb3React()
+
+  const swapAddress = chainId ? GP_SETTLEMENT_CONTRACT_ADDRESS[chainId] : null
+
+  return (
+    <ExternalLink href={chainId && swapAddress ? getEtherscanLink(chainId, swapAddress, 'address') : ''}>
+      <StyledPolling>
+        {VersionList.map(([key, val]) => (
+          <TYPE.small key={key}>
+            {key}: {val}
+          </TYPE.small>
+        ))}
+      </StyledPolling>
+    </ExternalLink>
+  )
+}
+
+export default Version

--- a/src/custom/pages/AppBody/AppBodyMod.tsx
+++ b/src/custom/pages/AppBody/AppBodyMod.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
+import Version from 'components/Version'
 
 export const BodyWrapper = styled.div`
   position: relative;
@@ -16,5 +17,10 @@ export const BodyWrapper = styled.div`
  * The styled container element that wraps the content of most pages and the tabs.
  */
 export default function AppBody({ children, className }: { children: React.ReactNode; className?: string }) {
-  return <BodyWrapper className={className}>{children}</BodyWrapper>
+  return (
+    <BodyWrapper className={className}>
+      {children}
+      <Version />
+    </BodyWrapper>
+  )
 }


### PR DESCRIPTION
Adds WEB and CONTRACTS versioning to app in bottom left, flush with operator status on bottom right

On hover:
![Screenshot from 2020-12-17 15-27-42](https://user-images.githubusercontent.com/21335563/102500548-b7e08880-407c-11eb-8723-c280a7d9b4c6.png)

Off hover:
![Screenshot from 2020-12-17 15-27-47](https://user-images.githubusercontent.com/21335563/102500561-badb7900-407c-11eb-92ad-1685ec0866ae.png)
