### PR TITLE
xDAI (temporary)

### DIFF
--- a/src/connectors/index.ts
+++ b/src/connectors/index.ts
@@ -27,7 +27,7 @@ export function getNetworkLibrary(): Web3Provider {
 }
 
 export const injected = new InjectedConnector({
-  supportedChainIds: [1, 3, 4, 5, 42]
+  supportedChainIds: [1, 3, 4, 5, 42, 100]
 })
 
 // mainnet only

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,7 +1,12 @@
-import { ChainId, JSBI, Percent, Token, WETH } from '@uniswap/sdk'
+import { ChainId, JSBI, Percent, Token, WETH as WETHuni } from '@uniswap/sdk'
 import { AbstractConnector } from '@web3-react/abstract-connector'
 
 import { fortmatic, injected, portis, walletconnect, walletlink } from '../connectors'
+
+const WETH = {
+  ...WETHuni,
+  100: new Token(100, '0x6A023CCd1ff6F2045C3309768eAd9E68F978f6e1', 18, 'WETH', 'Wrapped Ether on xDai')
+}
 
 export const ROUTER_ADDRESS = '0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D'
 
@@ -10,6 +15,8 @@ export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 // a list of tokens by chain
 type ChainTokenList = {
   readonly [chainId in ChainId]: Token[]
+} & {
+  readonly 100: Token[]
 }
 
 export const DAI = new Token(ChainId.MAINNET, '0x6B175474E89094C44Da98b954EedeAC495271d0F', 18, 'DAI', 'Dai Stablecoin')
@@ -54,7 +61,8 @@ const WETH_ONLY: ChainTokenList = {
   [ChainId.ROPSTEN]: [WETH[ChainId.ROPSTEN]],
   [ChainId.RINKEBY]: [WETH[ChainId.RINKEBY]],
   [ChainId.GÖRLI]: [WETH[ChainId.GÖRLI]],
-  [ChainId.KOVAN]: [WETH[ChainId.KOVAN]]
+  [ChainId.KOVAN]: [WETH[ChainId.KOVAN]],
+  100: [WETH[100]]
 }
 
 // used to construct intermediary pairs for trading

--- a/src/constants/multicall/index.ts
+++ b/src/constants/multicall/index.ts
@@ -1,12 +1,13 @@
 import { ChainId } from '@uniswap/sdk'
 import MULTICALL_ABI from './abi.json'
 
-const MULTICALL_NETWORKS: { [chainId in ChainId]: string } = {
+const MULTICALL_NETWORKS: { [chainId in ChainId]: string } & { 100: string } = {
   [ChainId.MAINNET]: '0xeefBa1e63905eF1D7ACbA5a8513c70307C1cE441',
   [ChainId.ROPSTEN]: '0x53C43764255c17BD724F74c4eF150724AC50a3ed',
   [ChainId.KOVAN]: '0x2cc8688C5f75E365aaEEb4ea8D6a480405A48D2A',
   [ChainId.RINKEBY]: '0x42Ad527de7d4e9d9d011aC45B31D8551f8Fe9821',
-  [ChainId.GÖRLI]: '0x77dCa2C955b15e9dE4dbBCf1246B4B85b651e50e'
+  [ChainId.GÖRLI]: '0x77dCa2C955b15e9dE4dbBCf1246B4B85b651e50e',
+  100: '0xe849a78ed40691d1e1512dbcbb3bcd78491ddba9'
 }
 
 export { MULTICALL_ABI, MULTICALL_NETWORKS }

--- a/src/custom/hooks/useContract.ts
+++ b/src/custom/hooks/useContract.ts
@@ -2,10 +2,9 @@ import { Contract } from '@ethersproject/contracts'
 import { useActiveWeb3React } from 'hooks'
 
 import { useContract } from '@src/hooks/useContract'
-export * from '@src/hooks/useContract'
-
 import { GP_SETTLEMENT_CONTRACT_ADDRESS } from 'constants/index'
 import { GP_V2_SETTLEMENT_INTERFACE } from 'constants/GPv2Settlement'
+export * from '@src/hooks/useContract'
 
 export function useGP2SettlementContract(): Contract | null {
   const { chainId } = useActiveWeb3React()

--- a/src/data/V1.ts
+++ b/src/data/V1.ts
@@ -13,7 +13,7 @@ import {
   TokenAmount,
   Trade,
   TradeType,
-  WETH
+  WETH as WETHuni
 } from '@uniswap/sdk'
 import { useMemo } from 'react'
 import { useActiveWeb3React } from '../hooks'
@@ -22,6 +22,11 @@ import { useV1FactoryContract } from '../hooks/useContract'
 import { Version } from '../hooks/useToggledVersion'
 import { NEVER_RELOAD, useSingleCallResult, useSingleContractMultipleData } from '../state/multicall/hooks'
 import { useETHBalances, useTokenBalance, useTokenBalances } from '../state/wallet/hooks'
+
+const WETH = {
+  ...WETHuni,
+  100: new Token(100, '0x6A023CCd1ff6F2045C3309768eAd9E68F978f6e1', 18, 'WETH', 'Wrapped Ether on xDai')
+}
 
 export function useV1ExchangeAddress(tokenAddress?: string): string | undefined {
   const contract = useV1FactoryContract()

--- a/src/hooks/Tokens.ts
+++ b/src/hooks/Tokens.ts
@@ -58,10 +58,12 @@ export function useToken(tokenAddress?: string): Token | undefined | null {
   const address = isAddress(tokenAddress)
 
   const tokenContract = useTokenContract(address ? address : undefined, false)
+  console.log('tokenContract', tokenContract)
   const tokenContractBytes32 = useBytes32TokenContract(address ? address : undefined, false)
   const token: Token | undefined = address ? tokens[address] : undefined
 
   const tokenName = useSingleCallResult(token ? undefined : tokenContract, 'name', undefined, NEVER_RELOAD)
+  console.log('tokenName', tokenName)
   const tokenNameBytes32 = useSingleCallResult(
     token ? undefined : tokenContractBytes32,
     'name',

--- a/src/hooks/useContract.ts
+++ b/src/hooks/useContract.ts
@@ -3,7 +3,7 @@ import { abi as GOVERNANCE_ABI } from '@uniswap/governance/build/GovernorAlpha.j
 import { abi as UNI_ABI } from '@uniswap/governance/build/Uni.json'
 import { abi as STAKING_REWARDS_ABI } from '@uniswap/liquidity-staker/build/StakingRewards.json'
 import { abi as MERKLE_DISTRIBUTOR_ABI } from '@uniswap/merkle-distributor/build/MerkleDistributor.json'
-import { ChainId, WETH } from '@uniswap/sdk'
+import { ChainId, WETH as WETHuni, Token } from '@uniswap/sdk'
 import { abi as IUniswapV2PairABI } from '@uniswap/v2-core/build/IUniswapV2Pair.json'
 import { useMemo } from 'react'
 import { GOVERNANCE_ADDRESS, MERKLE_DISTRIBUTOR_ADDRESS, UNI } from '../constants'
@@ -22,6 +22,11 @@ import { MULTICALL_ABI, MULTICALL_NETWORKS } from '../constants/multicall'
 import { V1_EXCHANGE_ABI, V1_FACTORY_ABI, V1_FACTORY_ADDRESSES } from '../constants/v1'
 import { getContract } from '../utils'
 import { useActiveWeb3React } from './index'
+
+const WETH = {
+  ...WETHuni,
+  100: new Token(100, '0x6A023CCd1ff6F2045C3309768eAd9E68F978f6e1', 18, 'WETH', 'Wrapped Ether on xDai')
+}
 
 // returns null on errors
 export function useContract(address: string | undefined, ABI: any, withSignerIfPossible = true): Contract | null {

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -99,7 +99,9 @@ export default function Swap() {
     [Version.v1]: v1Trade,
     [Version.v2]: v2Trade
   }
+  console.log('tradesByVersion', tradesByVersion)
   const trade = showWrap ? undefined : tradesByVersion[toggledVersion]
+  console.log('trade', trade)
   const defaultTrade = showWrap ? undefined : tradesByVersion[DEFAULT_VERSION]
 
   const betterTradeLinkVersion: Version | undefined =


### PR DESCRIPTION
THIS DOESNT WORK <sub>yet</sub>

- Add Multicall contract
- Add xDAI as allowed chainId for InjectedProvider (MMask)
- Add WETH in a bunch of places(temp)
- Can't find price route --> can't find a trade --> always `Insufficient liqudity for this trade`

Ideas to overcome issues:

- Real liquidity, with real price routes on xDAI
- Somehow substitute Mainnet data
- Borrow an xDAI router contract (@W3stside's idea)

No token list to speak of so need to get tokens form url, [for example](https://pr85--gpv2swap.review.gnosisdev.com/#/swap?inputCurrency=0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d&outputCurrency=0x9C58BAcC331c9aa871AFD802DB6379a98e80CEdb)